### PR TITLE
Add executable jar opts in gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,10 @@ eclipse {
     }
 }
 
+springBoot {
+  executable = true
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '2.10'
 }


### PR DESCRIPTION
Add [executable options](https://docs.spring.io/spring-boot/docs/current/reference/html/deployment-install.html) for easily starting the broker as a daemon with a PID file.  This will be useful for running as a BOSH release.