### PR TITLE
Update to latest Spring Cloud Service Broker RC

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ including:
 To build, make sure that you have a Java 8 runtime environment, and use Gradle.
 
 ```
+# start up the ecs-simulator to satisfy the test-suite
+./gradlew simulate &
+
+# Then build the project
 ./gradlew build
 ```
 

--- a/src/main/java/com/emc/ecs/serviceBroker/service/EcsServiceInstanceBindingService.java
+++ b/src/main/java/com/emc/ecs/serviceBroker/service/EcsServiceInstanceBindingService.java
@@ -11,6 +11,7 @@ import javax.xml.bind.JAXBException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingExistsException;
+import org.springframework.cloud.servicebroker.model.CreateServiceInstanceAppBindingResponse;
 import org.springframework.cloud.servicebroker.model.CreateServiceInstanceBindingRequest;
 import org.springframework.cloud.servicebroker.model.CreateServiceInstanceBindingResponse;
 import org.springframework.cloud.servicebroker.model.DeleteServiceInstanceBindingRequest;
@@ -72,7 +73,7 @@ public class EcsServiceInstanceBindingService implements ServiceInstanceBindingS
 			e.printStackTrace();
 			throw new ServiceBrokerException(e.getMessage());
 		}
-		return new CreateServiceInstanceBindingResponse(credentials);
+		return new CreateServiceInstanceAppBindingResponse().withCredentials(credentials);
 	}
 
 	@Override

--- a/src/main/java/com/emc/ecs/serviceBroker/service/EcsServiceInstanceService.java
+++ b/src/main/java/com/emc/ecs/serviceBroker/service/EcsServiceInstanceService.java
@@ -105,6 +105,6 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
 	@Override
 	public GetLastServiceOperationResponse getLastOperation(
 			GetLastServiceOperationRequest request) {
-		return new GetLastServiceOperationResponse(null);
+		return new GetLastServiceOperationResponse();
 	}
 }

--- a/src/test/java/com/emc/ecs/serviceBroker/repository/BucketServiceInstanceServiceTest.java
+++ b/src/test/java/com/emc/ecs/serviceBroker/repository/BucketServiceInstanceServiceTest.java
@@ -59,7 +59,7 @@ public class BucketServiceInstanceServiceTest {
 		creds.put("endpoint", ecs.getObjectEndpoint());
 		creds.put("baseUrl", ecs.getBaseUrl());
 		ServiceInstanceBinding binding = new ServiceInstanceBinding(
-				ServiceInstanceBindingFixture.buildCreateBindingRequestForApp());
+				ServiceInstanceBindingFixture.buildCreateAppBindingRequest());
 		binding.setBindingId("service-inst-bind-one-id");
 		binding.setCredentials(creds);
 		return binding;


### PR DESCRIPTION
The most recent [Spring Cloud Service Broker](https://github.com/spring-cloud/spring-cloud-cloudfoundry-service-broker) release candidate introduced a couple of API changes.  The PR updates to the latest API. 