### PR TITLE
Fix for auth timeouts

### DIFF
--- a/src/main/java/com/emc/ecs/managementClient/Connection.java
+++ b/src/main/java/com/emc/ecs/managementClient/Connection.java
@@ -119,6 +119,7 @@ public class Connection {
 			throw new EcsManagementClientException(e.getMessage());
 		}
 		this.authToken = response.getHeaderString("X-SDS-AUTH-TOKEN");
+		this.authRetries = 0;
 	}
 
 	public void logout() throws EcsManagementClientException {


### PR DESCRIPTION
If the broker has been running long enough for the ECS client to timeout and reconnect more than three times, the `authRetries` wasn't being reset, so it would stop retrying.  The resets `authRetries` to zero upon a successful login.