### PR TITLE
Replace constructors with PostConstruct methods

### DIFF
--- a/src/main/java/com/emc/ecs/serviceBroker/EcsService.java
+++ b/src/main/java/com/emc/ecs/serviceBroker/EcsService.java
@@ -39,17 +39,12 @@ public class EcsService {
 	@Autowired
 	private CatalogConfig catalog;
 
-	public EcsService() throws EcsManagementClientException,
-					EcsManagementResourceNotFoundException {
-		super();
-	}
-	
 	@PostConstruct
 	public void initialize() throws EcsManagementClientException,
 			EcsManagementResourceNotFoundException {
 		prepareRepository();
 	}
-	
+
 	public void prepareRepository() throws EcsManagementClientException,
 			EcsManagementResourceNotFoundException {
 		String bucketName = broker.getRepositoryBucket();

--- a/src/main/java/com/emc/ecs/serviceBroker/config/Application.java
+++ b/src/main/java/com/emc/ecs/serviceBroker/config/Application.java
@@ -60,7 +60,7 @@ public class Application {
 	public ServiceInstanceRepository serviceInstanceRepository()
 			throws EcsManagementClientException,
 			EcsManagementResourceNotFoundException, URISyntaxException {
-		return new ServiceInstanceRepository(broker);
+		return new ServiceInstanceRepository();
 	}
 
 	@Bean
@@ -74,7 +74,7 @@ public class Application {
 	public ServiceInstanceBindingRepository serviceInstanceBindingRepository()
 			throws EcsManagementClientException,
 			EcsManagementResourceNotFoundException, URISyntaxException {
-		return new ServiceInstanceBindingRepository(broker);
+		return new ServiceInstanceBindingRepository();
 	}
 	
 	public static void main(String[] args) {

--- a/src/main/java/com/emc/ecs/serviceBroker/repository/ServiceInstanceBindingRepository.java
+++ b/src/main/java/com/emc/ecs/serviceBroker/repository/ServiceInstanceBindingRepository.java
@@ -7,10 +7,10 @@ import java.io.PipedOutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import javax.annotation.PostConstruct;
 import javax.xml.bind.JAXBException;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import com.emc.ecs.serviceBroker.EcsManagementClientException;
 import com.emc.ecs.serviceBroker.EcsManagementResourceNotFoundException;
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@Component
 public class ServiceInstanceBindingRepository {
 
 	private S3JerseyClient s3;
@@ -30,10 +29,12 @@ public class ServiceInstanceBindingRepository {
 	private ObjectMapper objectMapper = new ObjectMapper();
 
 	@Autowired
-	public ServiceInstanceBindingRepository(BrokerConfig broker)
+	BrokerConfig broker;
+	
+	@PostConstruct
+	public void initialize()
 			throws EcsManagementClientException,
 			EcsManagementResourceNotFoundException, URISyntaxException {
-		super();
 		S3Config s3Config = new S3Config(
 				new URI(broker.getRepositoryEndpoint()));
 		s3Config.withIdentity(broker.getPrefixedUserName())

--- a/src/main/java/com/emc/ecs/serviceBroker/repository/ServiceInstanceRepository.java
+++ b/src/main/java/com/emc/ecs/serviceBroker/repository/ServiceInstanceRepository.java
@@ -7,10 +7,10 @@ import java.io.PipedOutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import javax.annotation.PostConstruct;
 import javax.xml.bind.JAXBException;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import com.emc.ecs.serviceBroker.EcsManagementClientException;
 import com.emc.ecs.serviceBroker.EcsManagementResourceNotFoundException;
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@Component
 public class ServiceInstanceRepository {
 
 	private String bucket;
@@ -30,10 +29,13 @@ public class ServiceInstanceRepository {
 	private ObjectMapper objectMapper = new ObjectMapper();
 
 	@Autowired
-	public ServiceInstanceRepository(BrokerConfig broker)
+	BrokerConfig broker;
+
+	
+	@PostConstruct
+	public void initialize()
 			throws EcsManagementClientException,
 			EcsManagementResourceNotFoundException, URISyntaxException {
-		super();
 		S3Config s3Config = new S3Config(
 				new URI(broker.getRepositoryEndpoint()));
 		s3Config.withIdentity(broker.getPrefixedUserName())

--- a/src/test/java/com/emc/ecs/serviceBroker/repository/BucketServiceInstanceBindingServiceTest.java
+++ b/src/test/java/com/emc/ecs/serviceBroker/repository/BucketServiceInstanceBindingServiceTest.java
@@ -19,7 +19,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import com.emc.ecs.serviceBroker.EcsManagementClientException;
 import com.emc.ecs.serviceBroker.EcsManagementResourceNotFoundException;
 import com.emc.ecs.serviceBroker.config.Application;
-import com.emc.ecs.serviceBroker.config.BrokerConfig;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = Application.class, initializers = ConfigFileApplicationContextInitializer.class)
@@ -27,12 +26,11 @@ import com.emc.ecs.serviceBroker.config.BrokerConfig;
 public class BucketServiceInstanceBindingServiceTest {
 
 	@Autowired
-	private BrokerConfig broker;
+	private ServiceInstanceRepository repository;
 
 	@Test
 	public void testSaveFindDelete() throws IOException, JAXBException, EcsManagementClientException,
 			EcsManagementResourceNotFoundException, URISyntaxException {
-		ServiceInstanceRepository repository = new ServiceInstanceRepository(broker);
 		ServiceInstance instance = serviceInstanceFixture();
 		repository.save(instance);
 		ServiceInstance instance2 = repository.find(instance.getServiceInstanceId());

--- a/src/test/java/com/emc/ecs/serviceBroker/repository/BucketServiceInstanceServiceTest.java
+++ b/src/test/java/com/emc/ecs/serviceBroker/repository/BucketServiceInstanceServiceTest.java
@@ -22,26 +22,23 @@ import com.emc.ecs.serviceBroker.EcsManagementClientException;
 import com.emc.ecs.serviceBroker.EcsManagementResourceNotFoundException;
 import com.emc.ecs.serviceBroker.EcsService;
 import com.emc.ecs.serviceBroker.config.Application;
-import com.emc.ecs.serviceBroker.config.BrokerConfig;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = Application.class,
 	initializers = ConfigFileApplicationContextInitializer.class)
 @ActiveProfiles("development")
 public class BucketServiceInstanceServiceTest {
-
+	
 	@Autowired
-	private EcsService ecs;
-
+	EcsService ecs;
+	
 	@Autowired
-	private BrokerConfig broker;
+	ServiceInstanceBindingRepository repository;
 
 	@Test
 	public void testSaveFindDelete()
 			throws IOException, JAXBException, EcsManagementClientException,
 			EcsManagementResourceNotFoundException, URISyntaxException {
-		ServiceInstanceBindingRepository repository = new ServiceInstanceBindingRepository(
-				broker);
 		ServiceInstanceBinding binding = bindingInstanceFixture();
 		repository.save(binding);
 		ServiceInstanceBinding binding2 = repository.find(binding.getBindingId());


### PR DESCRIPTION
The constructors fire before bean creation, which causes periodic race conditions when a repository action fires before the EcsService is ready.  Resolves #23.