### PR TITLE
Removes Gradle forcing of spring.profiles.active to production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 before_script:
   - "./gradlew simulate &"
   - "sleep 5"
+env:
+  - SPRING_PROFILES_ACTIVE=development
 after_script:
   - "kill %1"
 jdk:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To build, make sure that you have a Java 8 runtime environment, and use Gradle.
 ./gradlew simulate &
 
 # Then build the project
-./gradlew build
+SPRING_PROFILES_ACTIVE=development ./gradlew build
 ```
 
 ## Configuration
@@ -207,7 +207,7 @@ First start the simulator either within Eclipse, or via the command-line:
 You can then run the test-suite with gradle:
 
 ```
-./gradlew test
+SPRING_PROFILES_ACTIVE=development ./gradlew test
 ```
 
 ## TODOs

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,3 @@ task simulate(type:JavaExec) {
 	classpath sourceSets.test.runtimeClasspath
 	main = "com.emc.ecs.apiSimulator.Server"
 }
-
-tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
-  systemProperty('spring.profiles.active', 'production')
-}


### PR DESCRIPTION
These lines (now deleted) in the Gradle config are forcing gradle to run in the production profile, which may not be desired.  The effect of removing this, is that an environment variable, `SPRING_PROFILES_ACTIVE`, is required.