### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/src/main/java/com/emc/ecs/managementClient/BucketAction.java
+++ b/src/main/java/com/emc/ecs/managementClient/BucketAction.java
@@ -9,10 +9,14 @@ import com.emc.ecs.serviceBroker.EcsManagementClientException;
 
 public class BucketAction {
 
+	private static final String BUCKET = "bucket";
+	private static final String OBJECT = "object";
+	private static final String NAMESPACE = "namespace";
+
 	public static void create(Connection connection, String id,
 			String namespace, String replicationGroup)
 					throws EcsManagementClientException {
-		UriBuilder uri = connection.getUriBuilder().segment("object", "bucket");
+		UriBuilder uri = connection.getUriBuilder().segment(OBJECT, BUCKET);
 		connection.handleRemoteCall("post", uri,
 				new ObjectBucketCreate(id, namespace, replicationGroup));
 	}
@@ -20,23 +24,23 @@ public class BucketAction {
 	public static void create(Connection connection,
 			ObjectBucketCreate createParam)
 					throws EcsManagementClientException {
-		UriBuilder uri = connection.getUriBuilder().segment("object", "bucket");
+		UriBuilder uri = connection.getUriBuilder().segment(OBJECT, BUCKET);
 		connection.handleRemoteCall("post", uri, createParam);
 	}
 
 	public static boolean exists(Connection connection, String id,
 			String namespace) throws EcsManagementClientException {
 		UriBuilder uri = connection.getUriBuilder()
-				.segment("object", "bucket", id, "info")
-				.queryParam("namespace", namespace);
+				.segment(OBJECT, BUCKET, id, "info")
+				.queryParam(NAMESPACE, namespace);
 		return connection.existenceQuery(uri, null);
 	}
 
 	public static ObjectBucketInfo get(Connection connection, String id,
 			String namespace) throws EcsManagementClientException {
 		UriBuilder uri = connection.getUriBuilder()
-				.segment("object", "bucket", id, "info")
-				.queryParam("namespace", namespace);
+				.segment(OBJECT, BUCKET, id, "info")
+				.queryParam(NAMESPACE, namespace);
 		Response response = connection.handleRemoteCall("get", uri, null);
 		ObjectBucketInfo info = response.readEntity(ObjectBucketInfo.class);
 		return info;
@@ -45,8 +49,8 @@ public class BucketAction {
 	public static void delete(Connection connection, String id,
 			String namespace) throws EcsManagementClientException {
 		UriBuilder uri = connection.getUriBuilder()
-				.segment("object", "bucket", id, "deactivate")
-				.queryParam("namespace", namespace);
+				.segment(OBJECT, BUCKET, id, "deactivate")
+				.queryParam(NAMESPACE, namespace);
 		connection.handleRemoteCall("post", uri, null);
 	}
 

--- a/src/main/java/com/emc/ecs/managementClient/ObjectUserAction.java
+++ b/src/main/java/com/emc/ecs/managementClient/ObjectUserAction.java
@@ -8,9 +8,12 @@ import com.emc.ecs.serviceBroker.EcsManagementClientException;
 
 public class ObjectUserAction {
 
+	private static final String USERS = "users";
+	private static final String OBJECT = "object";
+	
 	public static void create(Connection connection, String id,
 			String namespace) throws EcsManagementClientException {
-		UriBuilder uri = connection.getUriBuilder().segment("object", "users");
+		UriBuilder uri = connection.getUriBuilder().segment(OBJECT, USERS);
 		connection.handleRemoteCall("post", uri,
 				new UserCreateParam(id, namespace));
 	}
@@ -18,14 +21,14 @@ public class ObjectUserAction {
 	public static boolean exists(Connection connection, String id,
 			String namespace) throws EcsManagementClientException {
 		UriBuilder uri = connection.getUriBuilder()
-				.segment("object", "users", id, "info")
+				.segment(OBJECT, USERS, id, "info")
 				.queryParam("namespace", namespace);
 		return connection.existenceQuery(uri, null);
 	}
 
 	public static void delete(Connection connection, String id)
 			throws EcsManagementClientException {
-		UriBuilder uri = connection.getUriBuilder().segment("object", "users",
+		UriBuilder uri = connection.getUriBuilder().segment(OBJECT, USERS,
 				"deactivate");
 		connection.handleRemoteCall("post", uri, new UserDeleteParam(id));
 	}

--- a/src/main/java/com/emc/ecs/managementClient/ObjectUserSecretAction.java
+++ b/src/main/java/com/emc/ecs/managementClient/ObjectUserSecretAction.java
@@ -12,10 +12,13 @@ import com.emc.ecs.serviceBroker.EcsManagementClientException;
 
 public class ObjectUserSecretAction {
 
+	private static final String OBJECT = "object";
+	private static final String USER_SECRET_KEYS = "user-secret-keys";
+
 	public static UserSecretKey create(Connection connection, String id)
 			throws EcsManagementClientException {
-		UriBuilder uri = connection.getUriBuilder().segment("object",
-				"user-secret-keys", id);
+		UriBuilder uri = connection.getUriBuilder().segment(OBJECT,
+				USER_SECRET_KEYS, id);
 		Response response = connection.handleRemoteCall("post", uri,
 				new UserSecretKeyCreate());
 		return response.readEntity(UserSecretKey.class);
@@ -23,8 +26,8 @@ public class ObjectUserSecretAction {
 
 	public static UserSecretKey create(Connection connection, String id,
 			String key) throws EcsManagementClientException {
-		UriBuilder uri = connection.getUriBuilder().segment("object",
-				"user-secret-keys", id);
+		UriBuilder uri = connection.getUriBuilder().segment(OBJECT,
+				USER_SECRET_KEYS, id);
 		Response response = connection.handleRemoteCall("post", uri,
 				new UserSecretKeyCreate(key));
 		return response.readEntity(UserSecretKey.class);
@@ -32,8 +35,8 @@ public class ObjectUserSecretAction {
 
 	public static List<UserSecretKey> list(Connection connection, String id)
 			throws EcsManagementClientException {
-		UriBuilder uri = connection.getUriBuilder().segment("object",
-				"user-secret-keys", id);
+		UriBuilder uri = connection.getUriBuilder().segment(OBJECT,
+				USER_SECRET_KEYS, id);
 		Response response = connection.handleRemoteCall("get", uri, null);
 		return response.readEntity(UserSecretKeyList.class).asList();
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1192 - String literals should not be duplicated

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1192

Please let me know if you have any questions.

M-Ezzat