### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/emc/ecs/managementClient/BaseUrlAction.java
+++ b/src/main/java/com/emc/ecs/managementClient/BaseUrlAction.java
@@ -10,7 +10,9 @@ import com.emc.ecs.managementClient.model.BaseUrlInfo;
 import com.emc.ecs.managementClient.model.BaseUrlList;
 import com.emc.ecs.serviceBroker.EcsManagementClientException;
 
-public class BaseUrlAction {
+public final class BaseUrlAction {
+
+	private BaseUrlAction() {}
 
 	public static List<BaseUrl> list(Connection connection)
 			throws EcsManagementClientException {

--- a/src/main/java/com/emc/ecs/managementClient/BucketAclAction.java
+++ b/src/main/java/com/emc/ecs/managementClient/BucketAclAction.java
@@ -6,7 +6,10 @@ import javax.ws.rs.core.UriBuilder;
 import com.emc.ecs.managementClient.model.BucketAcl;
 import com.emc.ecs.serviceBroker.EcsManagementClientException;
 
-public class BucketAclAction {
+public final class BucketAclAction {
+
+	private BucketAclAction() {}
+
 	public static void update(Connection connection, String id, BucketAcl acl)
 			throws EcsManagementClientException {
 		UriBuilder uri = connection.getUriBuilder().segment("object", "bucket",

--- a/src/main/java/com/emc/ecs/managementClient/BucketAction.java
+++ b/src/main/java/com/emc/ecs/managementClient/BucketAction.java
@@ -7,11 +7,13 @@ import com.emc.ecs.managementClient.model.ObjectBucketCreate;
 import com.emc.ecs.managementClient.model.ObjectBucketInfo;
 import com.emc.ecs.serviceBroker.EcsManagementClientException;
 
-public class BucketAction {
+public final class BucketAction {
 
 	private static final String BUCKET = "bucket";
 	private static final String OBJECT = "object";
 	private static final String NAMESPACE = "namespace";
+
+	private BucketAction() {}
 
 	public static void create(Connection connection, String id,
 			String namespace, String replicationGroup)

--- a/src/main/java/com/emc/ecs/managementClient/BucketQuotaAction.java
+++ b/src/main/java/com/emc/ecs/managementClient/BucketQuotaAction.java
@@ -5,7 +5,9 @@ import javax.ws.rs.core.UriBuilder;
 import com.emc.ecs.managementClient.model.BucketQuotaParam;
 import com.emc.ecs.serviceBroker.EcsManagementClientException;
 
-public class BucketQuotaAction {
+public final class BucketQuotaAction {
+
+	private BucketQuotaAction() {}
 
 	public static void create(Connection connection, String id,
 			String namespace, long limit, long warn)

--- a/src/main/java/com/emc/ecs/managementClient/ObjectUserAction.java
+++ b/src/main/java/com/emc/ecs/managementClient/ObjectUserAction.java
@@ -6,11 +6,13 @@ import com.emc.ecs.managementClient.model.UserCreateParam;
 import com.emc.ecs.managementClient.model.UserDeleteParam;
 import com.emc.ecs.serviceBroker.EcsManagementClientException;
 
-public class ObjectUserAction {
+public final class ObjectUserAction {
 
 	private static final String USERS = "users";
 	private static final String OBJECT = "object";
 	
+	private ObjectUserAction() {}
+
 	public static void create(Connection connection, String id,
 			String namespace) throws EcsManagementClientException {
 		UriBuilder uri = connection.getUriBuilder().segment(OBJECT, USERS);

--- a/src/main/java/com/emc/ecs/managementClient/ObjectUserSecretAction.java
+++ b/src/main/java/com/emc/ecs/managementClient/ObjectUserSecretAction.java
@@ -10,10 +10,12 @@ import com.emc.ecs.managementClient.model.UserSecretKeyCreate;
 import com.emc.ecs.managementClient.model.UserSecretKeyList;
 import com.emc.ecs.serviceBroker.EcsManagementClientException;
 
-public class ObjectUserSecretAction {
+public final class ObjectUserSecretAction {
 
 	private static final String OBJECT = "object";
 	private static final String USER_SECRET_KEYS = "user-secret-keys";
+
+	private ObjectUserSecretAction() {}
 
 	public static UserSecretKey create(Connection connection, String id)
 			throws EcsManagementClientException {

--- a/src/main/java/com/emc/ecs/managementClient/ReplicationGroupAction.java
+++ b/src/main/java/com/emc/ecs/managementClient/ReplicationGroupAction.java
@@ -12,7 +12,9 @@ import com.emc.ecs.managementClient.model.DataServiceReplicationGroupList;
 import com.emc.ecs.serviceBroker.EcsManagementClientException;
 import com.emc.ecs.serviceBroker.EcsManagementResourceNotFoundException;
 
-public class ReplicationGroupAction {
+public final class ReplicationGroupAction {
+
+	private ReplicationGroupAction() {}
 
 	public static List<DataServiceReplicationGroup> list(Connection connection)
 			throws EcsManagementClientException {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat