### PR TITLE
Add bucket encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,14 @@ Valid permissions include:
 The service broker catalog can be configured through YAML based configuration.  You can create the file manually,
 via PCF or another build tool.  Just add a `catalog` section to the `src/main/resources/application.yml` file:
 
-The following feature flags are supported by the bucket & namespace.  All parameters are optional, and can be set at the service or plan level in the `service-settings` block.  Parameters are observed with the following precedence:  service-definition (in the catalog), plan and then in command-line parameters.  While buckets don't currently support service-settings or command-line parameters, these will be added soon.
+The following feature flags are supported by the bucket & namespace.  All parameters are optional, and can be set at the service or plan level in the `service-settings` block.  Parameters are observed with the following precedence:  service-definition (in the catalog), plan and then in command-line parameters.  While buckets don't currently support service-settings or command-line parameters for retention & quotas, these will be added soon.
 
 | Resource          | Parameter           | Default Value  | Type       |  Description                                   |
 | :---------------- | :-------------------| :------------: | :--------- | :--------------------------------------------- |
+| bucket            | encrypted           | false          | Boolean    | Enable encryption of namespace                 |
+| bucket            | access-during-outage| false          | Boolean    | Enable potentially stale data during outage    |
+| bucket            | file-access         | false          | Boolean    | Enable file-access (NFS, HDFS) for bucket      |
+| bucket            | head-type           | s3             | String     | Specify object type (s3, swift) for bucket     |
 | bucket binding    | base-url            | -              | String     | Base URL name for object URI                   |
 | bucket binding    | use-ssl             | false          | Boolean    | Use SSL for object endpoint                    |
 | bucket binding    | permissions         | -              | JSON List  | List of permissions for user in bucket ACL     |

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/model/ServiceDefinitionProxy.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/model/ServiceDefinitionProxy.java
@@ -24,9 +24,6 @@ public class ServiceDefinitionProxy {
     private List<PlanProxy> plans;
     private List<String> requires;
     private DashboardClientProxy dashboardClient;
-    private String headType = "s3";
-    private Boolean fileSystemEnabled = false;
-    private Boolean staleAllowed = false;
 
     public ServiceDefinitionProxy() {
 	super();
@@ -144,30 +141,6 @@ public class ServiceDefinitionProxy {
 
     public void setDashboardClient(DashboardClientProxy dashboardClient) {
 	this.dashboardClient = dashboardClient;
-    }
-
-    public String getHeadType() {
-	return headType;
-    }
-
-    public void setHeadType(String headType) {
-	this.headType = headType;
-    }
-
-    public Boolean getFileSystemEnabled() {
-	return fileSystemEnabled;
-    }
-
-    public void setFileSystemEnabled(Boolean fileSystemEnabled) {
-	this.fileSystemEnabled = fileSystemEnabled;
-    }
-
-    public Boolean getStaleAllowed() {
-	return staleAllowed;
-    }
-
-    public void setStaleAllowed(Boolean staleAllowed) {
-	this.staleAllowed = staleAllowed;
     }
 
     public PlanProxy findPlan(String planId) {

--- a/src/main/java/com/emc/ecs/management/sdk/BucketQuotaAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/BucketQuotaAction.java
@@ -13,7 +13,7 @@ public final class BucketQuotaAction {
     }
 
     public static void create(Connection connection, String id,
-	    String namespace, long limit, long warn)
+	    String namespace, int limit, int warn)
 	    throws EcsManagementClientException {
 	UriBuilder uri = connection.getUriBuilder().segment(OBJECT, BUCKET, id,
 		QUOTA);

--- a/src/main/java/com/emc/ecs/management/sdk/Connection.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Connection.java
@@ -185,7 +185,7 @@ public class Connection {
 	try {
 	    handleResponse(response);
 	} catch (EcsManagementResourceNotFoundException e) {
-	    Logger.getAnonymousLogger().log(Level.INFO, "info", e);
+	    Logger.getAnonymousLogger().log(Level.FINE, "info", e);
 	    return false;
 	}
 	return true;

--- a/src/main/java/com/emc/ecs/management/sdk/model/ObjectBucketCreate.java
+++ b/src/main/java/com/emc/ecs/management/sdk/model/ObjectBucketCreate.java
@@ -1,17 +1,32 @@
 package com.emc.ecs.management.sdk.model;
 
+import java.util.Map;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "object_bucket_create")
 public class ObjectBucketCreate {
+    private Boolean filesystemEnabled = false;
+    private Boolean isStaleAllowed = false;
+    private String headType = "s3";
     private String name;
     private String vpool;
-    private Boolean filesystemEnabled = false;
-    private String headType = "s3";
     private String namespace;
+    private Boolean isEncryptionEnabled;
 
-    private Boolean isStaleAllowed = true;
+    public ObjectBucketCreate(String name, String namespace,
+	    String replicationGroup, Map<String, Object> params) {
+	super();
+	this.name = name;
+	this.namespace = namespace;
+	this.vpool = replicationGroup;
+	this.isEncryptionEnabled = (Boolean) params.get("encrypted");
+	this.filesystemEnabled = (Boolean) params.get("file-accessible");
+	this.isStaleAllowed = (Boolean) params.get("access-during-outage");
+	this.headType = (String) params.getOrDefault("head-type", "s3");
+
+    }
 
     public ObjectBucketCreate(String name, String namespace,
 	    String replicationGroup) {
@@ -74,5 +89,14 @@ public class ObjectBucketCreate {
 
     public void setIsStaleAllowed(Boolean isStaleAllowed) {
 	this.isStaleAllowed = isStaleAllowed;
+    }
+
+    @XmlElement(name = "is_encryption_enabled")
+    public Boolean getIsEncryptionEnabled() {
+	return isEncryptionEnabled;
+    }
+
+    public void setIsEncryptionEnabled(Boolean isEncryptionEnabled) {
+	this.isEncryptionEnabled = isEncryptionEnabled;
     }
 }

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceBindingServiceTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceBindingServiceTest.java
@@ -36,6 +36,8 @@ import com.emc.ecs.management.sdk.model.UserSecretKey;
 @RunWith(MockitoJUnitRunner.class)
 public class EcsServiceInstanceBindingServiceTest {
 
+    private static final String COLON = ":";
+
     private static final String HTTP = "http://";
 
     private static final String SECRET_KEY = "secretKey";
@@ -83,7 +85,8 @@ public class EcsServiceInstanceBindingServiceTest {
 	ArgumentCaptor<ServiceInstanceBinding> bindingCaptor = ArgumentCaptor
 		.forClass(ServiceInstanceBinding.class);
 	when(ecs.prefix(BINDING_ID)).thenReturn(BINDING_ID);
-	when(ecs.prefix(BINDING_ID + ":TEST_KEY")).thenReturn(BINDING_ID + ":TEST_KEY");
+	when(ecs.prefix(BINDING_ID + COLON + TEST_KEY))
+		.thenReturn(BINDING_ID + COLON + TEST_KEY);
 	when(ecs.prefix(NAMESPACE)).thenReturn(NAMESPACE);
 	doNothing().when(repository).save(bindingCaptor.capture());
 
@@ -93,7 +96,8 @@ public class EcsServiceInstanceBindingServiceTest {
 	String s3Url = new StringBuilder()
 		.append(HTTP)
 		.append(BINDING_ID)
-		.append(":TEST_KEY")
+		.append(COLON)
+		.append(TEST_KEY)
 		.append("@ns1.example.com:9020")
 		.toString();
 	assertEquals(s3Url, creds.get("s3Url"));
@@ -128,7 +132,8 @@ public class EcsServiceInstanceBindingServiceTest {
 	ArgumentCaptor<ServiceInstanceBinding> bindingCaptor = ArgumentCaptor
 		.forClass(ServiceInstanceBinding.class);
 	when(ecs.prefix(BINDING_ID)).thenReturn(BINDING_ID);
-	when(ecs.prefix(BINDING_ID + ":TEST_KEY")).thenReturn(BINDING_ID + ":TEST_KEY");
+	when(ecs.prefix(BINDING_ID + COLON + TEST_KEY))
+		.thenReturn(BINDING_ID + COLON + TEST_KEY);
 	when(ecs.prefix(BUCKET_NAME)).thenReturn(BUCKET_NAME);
 	doNothing().when(repository).save(bindingCaptor.capture());
 
@@ -139,7 +144,8 @@ public class EcsServiceInstanceBindingServiceTest {
 	String s3Url = new StringBuilder()
 		.append(HTTP)
 		.append(BINDING_ID)
-		.append(":TEST_KEY")
+		.append(COLON)
+		.append(TEST_KEY)
 		.append("@127.0.0.1:9020/")
 		.append(BUCKET_NAME)
 		.toString();
@@ -178,7 +184,8 @@ public class EcsServiceInstanceBindingServiceTest {
 	ArgumentCaptor<ServiceInstanceBinding> bindingCaptor = ArgumentCaptor
 		.forClass(ServiceInstanceBinding.class);
 	when(ecs.prefix(BINDING_ID)).thenReturn(BINDING_ID);
-	when(ecs.prefix(BINDING_ID + ":TEST_KEY")).thenReturn(BINDING_ID + ":TEST_KEY");
+	when(ecs.prefix(BINDING_ID + COLON + TEST_KEY))
+		.thenReturn(BINDING_ID + COLON + TEST_KEY);
 	when(ecs.prefix(BUCKET_NAME)).thenReturn(BUCKET_NAME);
 	doNothing().when(repository).save(bindingCaptor.capture());
 
@@ -188,7 +195,8 @@ public class EcsServiceInstanceBindingServiceTest {
 	String s3Url = new StringBuilder()
 		.append(HTTP)
 		.append(BINDING_ID)
-		.append(":TEST_KEY")
+		.append(COLON)
+		.append(TEST_KEY)
 		.append("@127.0.0.1:9020/")
 		.append(BUCKET_NAME)
 		.toString();

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceServiceTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceServiceTest.java
@@ -132,7 +132,8 @@ public class EcsServiceInstanceServiceTest {
      * @throws IOException 
      */
     @Test
-    public void testCreateNamespaceServiceNullParams() throws EcsManagementClientException, IOException, JAXBException {
+    public void testCreateNamespaceServiceNullParams()
+	    throws EcsManagementClientException, IOException, JAXBException {
 	when(ecs.lookupServiceDefinition(NAMESPACE_SERVICE_ID))
 		.thenReturn(namespaceServiceFixture());
 

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
@@ -52,10 +52,12 @@ import com.emc.ecs.management.sdk.model.UserSecretKey;
 @RunWith(PowerMockRunner.class)
 public class EcsServiceTest {
 
+    private static final String DOT = ".";
     private static final String HTTPS = "https://";
     private static final int THIRTY_DAYS_IN_SEC = 2592000;
     private static final String HTTP = "http://";
     private static final String _9020 = ":9020";
+    private static final String _9021 = ":9021";
     private static final String RETENTION = "retention";
     private static final String THIRTY_DAYS = "thirty-days";
     private static final String UPDATE = "update";
@@ -932,7 +934,7 @@ public class EcsServiceTest {
 		.thenReturn(baseUrlInfo);
 
 	String expectedUrl = new StringBuilder().append(HTTP).append(NAMESPACE)
-		.append(".").append(BASE_URL).append(_9020).toString();
+		.append(DOT).append(BASE_URL).append(_9020).toString();
 	assertEquals(expectedUrl, ecs.getNamespaceURL(NAMESPACE, service, plan,
 		Optional.ofNullable(null)));
     }
@@ -972,7 +974,7 @@ public class EcsServiceTest {
 		.thenReturn(baseUrlInfo);
 
 	String expectedUrl = new StringBuilder().append(HTTPS).append(NAMESPACE)
-		.append(".").append(BASE_URL).append(":9021").toString();
+		.append(DOT).append(BASE_URL).append(_9021).toString();
 	assertEquals(expectedUrl, ecs.getNamespaceURL(NAMESPACE, service, plan,
 		Optional.ofNullable(null)));
     }
@@ -1009,7 +1011,7 @@ public class EcsServiceTest {
 		.thenReturn(baseUrlInfo);
 
 	String expectedUrl = new StringBuilder().append(HTTP).append(NAMESPACE)
-		.append(".").append(BASE_URL).append(_9020).toString();
+		.append(DOT).append(BASE_URL).append(_9020).toString();
 	assertEquals(expectedUrl, ecs.getNamespaceURL(NAMESPACE, service, plan,
 		Optional.ofNullable(params)));
     }
@@ -1050,7 +1052,7 @@ public class EcsServiceTest {
 		.thenReturn(baseUrlInfo);
 
 	String expectedURl = new StringBuilder().append(HTTPS).append(NAMESPACE)
-		.append(".").append(BASE_URL).append(":9021").toString();
+		.append(DOT).append(BASE_URL).append(_9021).toString();
 	assertEquals(expectedURl, ecs.getNamespaceURL(NAMESPACE, service, plan,
 		Optional.ofNullable(params)));
     }

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -75,7 +75,18 @@ public class Fixtures {
 	bucketPlan1.setQuotaLimit(5);
 	bucketPlan1.setQuotaWarning(4);
 
-	List<PlanProxy> plans = Arrays.asList(bucketPlan1);
+	/*
+	 * Plan 2: No quota, encrypted, filesystem, access-during-outage.
+	 */
+	Map<String, Object> settings2 = new HashMap<>();
+	PlanProxy bucketPlan2 = new PlanProxy(BUCKET_PLAN_ID2, "Unlimited",
+		PAY_PER_GB_PER_MONTH, null, false);
+	settings2.put("encrypted", true);
+	settings2.put("access-during-outage", true);
+	settings2.put("file-accessible", true);
+	bucketPlan2.setServiceSettings(settings2);
+
+	List<PlanProxy> plans = Arrays.asList(bucketPlan1, bucketPlan2);
 
 	List<String> tags = Arrays.asList("ecs-bucket", "s3", "swift");
 	Map<String, Object> serviceSettings = new HashMap<>();

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -21,6 +21,8 @@ import com.emc.ecs.cloudfoundry.broker.repository.ServiceInstance;
 import com.emc.ecs.cloudfoundry.broker.repository.ServiceInstanceBinding;
 
 public class Fixtures {
+    private static final String ONE_YEAR = "one-year";
+    private static final int ONE_YEAR_IN_SECS = 31536000;
     private static final String FREE_TRIAL = "Free Trial";
     private static final String PAY_PER_GB_PER_MONTH = "Pay per GB Per Month";
     private static final String _5GB = "5gb";
@@ -116,7 +118,7 @@ public class Fixtures {
 	 * one-year retention.
 	 */
 	Map<String, Object> retention = new HashMap<>();
-	retention.put("one-year", 31536000);
+	retention.put(ONE_YEAR, ONE_YEAR_IN_SECS);
 	Map<String, Object> settings3 = new HashMap<>();
 	PlanProxy namespacePlan3 = new PlanProxy(NAMESPACE_PLAN_ID3,
 		"Compliant", PAY_PER_GB_PER_MONTH, null, false);

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -21,6 +21,7 @@ import com.emc.ecs.cloudfoundry.broker.repository.ServiceInstance;
 import com.emc.ecs.cloudfoundry.broker.repository.ServiceInstanceBinding;
 
 public class Fixtures {
+    private static final String UNLIMITED = "Unlimited";
     private static final String ONE_YEAR = "one-year";
     private static final int ONE_YEAR_IN_SECS = 31536000;
     private static final String FREE_TRIAL = "Free Trial";
@@ -79,7 +80,7 @@ public class Fixtures {
 	 * Plan 2: No quota, encrypted, filesystem, access-during-outage.
 	 */
 	Map<String, Object> settings2 = new HashMap<>();
-	PlanProxy bucketPlan2 = new PlanProxy(BUCKET_PLAN_ID2, "Unlimited",
+	PlanProxy bucketPlan2 = new PlanProxy(BUCKET_PLAN_ID2, UNLIMITED,
 		PAY_PER_GB_PER_MONTH, null, false);
 	settings2.put("encrypted", true);
 	settings2.put("access-during-outage", true);
@@ -117,7 +118,7 @@ public class Fixtures {
 	 */
 	Map<String, Object> settings2 = new HashMap<>();
 	PlanProxy namespacePlan2 = new PlanProxy(NAMESPACE_PLAN_ID2,
-		"Unlimited", PAY_PER_GB_PER_MONTH, null, false);
+		UNLIMITED, PAY_PER_GB_PER_MONTH, null, false);
 	settings2.put("encrypted", true);
 	settings2.put("domain-group-admins", EXTERNAL_ADMIN);
 	settings2.put("compliance-enabled", true);

--- a/src/test/java/com/emc/ecs/management/sdk/BucketAclActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/BucketAclActionTest.java
@@ -12,9 +12,6 @@ import org.junit.Test;
 import com.emc.ecs.cloudfoundry.broker.EcsManagementClientException;
 import com.emc.ecs.cloudfoundry.broker.EcsManagementResourceNotFoundException;
 import com.emc.ecs.common.EcsActionTest;
-import com.emc.ecs.management.sdk.BucketAclAction;
-import com.emc.ecs.management.sdk.BucketAction;
-import com.emc.ecs.management.sdk.ObjectUserAction;
 import com.emc.ecs.management.sdk.model.BucketAcl;
 import com.emc.ecs.management.sdk.model.BucketUserAcl;
 

--- a/src/test/java/com/emc/ecs/management/sdk/NamespaceActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/NamespaceActionTest.java
@@ -14,6 +14,8 @@ import com.emc.ecs.management.sdk.model.NamespaceUpdate;
 
 public class NamespaceActionTest extends EcsActionTest {
 
+    private static final String NOADMIN = "noadmin";
+
     @Before
     public void setUp() throws EcsManagementClientException {
 	connection.login();
@@ -35,7 +37,7 @@ public class NamespaceActionTest extends EcsActionTest {
 	    throws EcsManagementClientException,
 	    EcsManagementResourceNotFoundException {
 	assertFalse(NamespaceAction.exists(connection, namespace));
-	NamespaceAction.create(connection, namespace, "noadmin",
+	NamespaceAction.create(connection, namespace, NOADMIN,
 		replicationGroup);
 	assertTrue(NamespaceAction.exists(connection, namespace));
 	NamespaceAction.delete(connection, namespace);
@@ -45,7 +47,7 @@ public class NamespaceActionTest extends EcsActionTest {
     @Test
     public void getNamespaceTest() throws EcsManagementClientException,
 	    EcsManagementResourceNotFoundException {
-	NamespaceAction.create(connection, namespace, "noadmin",
+	NamespaceAction.create(connection, namespace, NOADMIN,
 		replicationGroup);
 	assertTrue(NamespaceAction.get(connection, namespace).getName()
 		.equals(namespace));
@@ -54,7 +56,7 @@ public class NamespaceActionTest extends EcsActionTest {
 
     @Test
     public void updateNamespaceTest() throws EcsManagementClientException {
-	NamespaceAction.create(connection, namespace, "noadmin",
+	NamespaceAction.create(connection, namespace, NOADMIN,
 		replicationGroup);
 	assertFalse(NamespaceAction.get(connection, namespace)
 		.getIsEncryptionEnabled());

--- a/src/test/java/com/emc/ecs/management/sdk/ReplicationGroupActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/ReplicationGroupActionTest.java
@@ -12,7 +12,6 @@ import static com.emc.ecs.common.Fixtures.*;
 import com.emc.ecs.cloudfoundry.broker.EcsManagementClientException;
 import com.emc.ecs.cloudfoundry.broker.EcsManagementResourceNotFoundException;
 import com.emc.ecs.common.EcsActionTest;
-import com.emc.ecs.management.sdk.ReplicationGroupAction;
 import com.emc.ecs.management.sdk.model.DataServiceReplicationGroup;
 
 public class ReplicationGroupActionTest extends EcsActionTest {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -49,13 +49,13 @@ catalog:
       description: Elastic Cloud S3 Object Storage Bucket
       bindable: true
       plan-updatable: true
-      head-type: s3
-      file-system-enabled: false
-      stale-allowed: true
       tags:
         - s3
       service-settings:
         service-type: bucket
+        head-type: s3
+        file-access: false
+        access-during-outage: true
       metadata:
         displayName: ecs-bucket
         imageUrl: http://www.emc.com/images/products/header-image-icon-ecs.png

--- a/src/test/resources/mappings/bucket-create-ecs-cf-broker-repository.json
+++ b/src/test/resources/mappings/bucket-create-ecs-cf-broker-repository.json
@@ -15,7 +15,7 @@
         },
         "bodyPatterns": [
         	{
-        		"equalToXml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><object_bucket_create><filesystem_enabled>false</filesystem_enabled><head_type>s3</head_type><is_stale_allowed>true</is_stale_allowed><name>ecs-cf-broker-repository</name><namespace>ns1</namespace><vpool>urn:storageos:ReplicationGroupInfo:2ef0a92d-cf88-4933-90ba-90245aa031b1:global</vpool></object_bucket_create>"
+        		"equalToXml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><object_bucket_create><head_type>s3</head_type><is_stale_allowed>true</is_stale_allowed><name>ecs-cf-broker-repository</name><namespace>ns1</namespace><vpool>urn:storageos:ReplicationGroupInfo:2ef0a92d-cf88-4933-90ba-90245aa031b1:global</vpool></object_bucket_create>"
         	}
         ]
     },

--- a/src/test/resources/mappings/bucket-create-testbucket2.json
+++ b/src/test/resources/mappings/bucket-create-testbucket2.json
@@ -15,7 +15,7 @@
         },
         "bodyPatterns": [
         	{
-        		"equalToXml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><object_bucket_create><filesystem_enabled>false</filesystem_enabled><head_type>s3</head_type><is_stale_allowed>true</is_stale_allowed><name>testbucket2</name><namespace>ns1</namespace><vpool>urn:storageos:ReplicationGroupInfo:2ef0a92d-cf88-4933-90ba-90245aa031b1:global</vpool></object_bucket_create>"
+        		"equalToXml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><object_bucket_create><filesystem_enabled>false</filesystem_enabled><head_type>s3</head_type><is_stale_allowed>false</is_stale_allowed><name>testbucket2</name><namespace>ns1</namespace><vpool>urn:storageos:ReplicationGroupInfo:2ef0a92d-cf88-4933-90ba-90245aa031b1:global</vpool></object_bucket_create>"
         	}
         ]
     },

--- a/src/test/resources/mappings/bucket-create-testbucket3.json
+++ b/src/test/resources/mappings/bucket-create-testbucket3.json
@@ -15,7 +15,7 @@
         },
         "bodyPatterns": [
         	{
-        		"equalToXml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><object_bucket_create><filesystem_enabled>false</filesystem_enabled><head_type>s3</head_type><is_stale_allowed>true</is_stale_allowed><name>testbucket3</name><namespace>ns1</namespace><vpool>urn:storageos:ReplicationGroupInfo:2ef0a92d-cf88-4933-90ba-90245aa031b1:global</vpool></object_bucket_create>"
+        		"equalToXml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><object_bucket_create><filesystem_enabled>false</filesystem_enabled><head_type>s3</head_type><is_stale_allowed>false</is_stale_allowed><name>testbucket3</name><namespace>ns1</namespace><vpool>urn:storageos:ReplicationGroupInfo:2ef0a92d-cf88-4933-90ba-90245aa031b1:global</vpool></object_bucket_create>"        		              
         	}
         ]
     },

--- a/src/test/resources/mappings/bucket-create-testbucket4.json
+++ b/src/test/resources/mappings/bucket-create-testbucket4.json
@@ -15,7 +15,7 @@
         },
         "bodyPatterns": [
         	{
-        		"equalToXml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><object_bucket_create><filesystem_enabled>false</filesystem_enabled><head_type>s3</head_type><is_stale_allowed>true</is_stale_allowed><name>testbucket4</name><namespace>ns1</namespace><vpool>urn:storageos:ReplicationGroupInfo:2ef0a92d-cf88-4933-90ba-90245aa031b1:global</vpool></object_bucket_create>"
+        		"equalToXml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><object_bucket_create><filesystem_enabled>false</filesystem_enabled><head_type>s3</head_type><is_stale_allowed>false</is_stale_allowed><name>testbucket4</name><namespace>ns1</namespace><vpool>urn:storageos:ReplicationGroupInfo:2ef0a92d-cf88-4933-90ba-90245aa031b1:global</vpool></object_bucket_create>"
         	}
         ]
     },


### PR DESCRIPTION
This PR adds bucket encryption, and also nests bucket settings into `service-settings` config block, which allows settings to be specified in service definition, plan or in command-line parameters.  This closes #45.