### PR TITLE
Multiple quality improvements - squid:S2974, squid:S2325, pmd:UseProp…

### DIFF
--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/config/Application.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/config/Application.java
@@ -32,7 +32,7 @@ public class Application {
 
     @Bean
     public Connection ecsConnection() {
-	URL certificate = getClass().getClassLoader()
+	URL certificate = Thread.currentThread().getContextClassLoader()
 		.getResource(broker.getCertificate());
 	return new Connection(broker.getManagementEndpoint(),
 		broker.getUsername(), broker.getPassword(), certificate);

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceBindingRepository.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceBindingRepository.java
@@ -60,7 +60,7 @@ public class ServiceInstanceBindingRepository {
 	s3.deleteObject(bucket, getFilename(id));
     }
 
-    private String getFilename(String id) {
+    private static String getFilename(String id) {
 	return "service-instance-binding/" + id + ".json";
     }
 

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceRepository.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/repository/ServiceInstanceRepository.java
@@ -60,7 +60,7 @@ public class ServiceInstanceRepository {
 	s3.deleteObject(bucket, getFilename(id));
     }
 
-    private String getFilename(String id) {
+    private static String getFilename(String id) {
 	return "service-instance/" + id + ".json";
     }
 

--- a/src/main/java/com/emc/ecs/management/sdk/Connection.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Connection.java
@@ -96,7 +96,7 @@ public class Connection {
 	}
     }
 
-    private HostnameVerifier getHostnameVerifier() {
+    private static HostnameVerifier getHostnameVerifier() {
 	return new HostnameVerifier() {
 	    @Override
 	    public boolean verify(String hostname, SSLSession session) {

--- a/src/main/java/com/emc/ecs/management/sdk/Constants.java
+++ b/src/main/java/com/emc/ecs/management/sdk/Constants.java
@@ -1,6 +1,6 @@
 package com.emc.ecs.management.sdk;
 
-public class Constants {
+public final class Constants {
     public static final String OBJECT = "object";
     public static final String NAMESPACES = "namespaces";
     public static final String NAMESPACE = "namespace";

--- a/src/main/java/com/emc/ecs/management/sdk/NamespaceQuotaAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/NamespaceQuotaAction.java
@@ -9,7 +9,7 @@ import com.emc.ecs.cloudfoundry.broker.EcsManagementClientException;
 import com.emc.ecs.management.sdk.model.NamespaceQuotaDetails;
 import com.emc.ecs.management.sdk.model.NamespaceQuotaParam;
 
-public class NamespaceQuotaAction {
+public final class NamespaceQuotaAction {
 
     private NamespaceQuotaAction() {}
 

--- a/src/main/java/com/emc/ecs/management/sdk/NamespaceRetentionAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/NamespaceRetentionAction.java
@@ -10,7 +10,7 @@ import com.emc.ecs.management.sdk.model.RetentionClassCreate;
 import com.emc.ecs.management.sdk.model.RetentionClassDetails;
 import com.emc.ecs.management.sdk.model.RetentionClassUpdate;
 
-public class NamespaceRetentionAction {
+public final class NamespaceRetentionAction {
 
     private NamespaceRetentionAction() {}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2974 - "private" methods that don't access instance data should be "static"
squid:S2325 - Classes without "public" constructors should be "final"
pmd:UseProperClassLoader - Use Proper Class Loader

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325
https://dev.eclipse.org/sonar/coding_rules#q=pmd:UseProperClassLoader

Please let me know if you have any questions.

M-Ezzat