### PR TITLE
New bucket quota settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,26 +124,27 @@ Valid permissions include:
 The service broker catalog can be configured through YAML based configuration.  You can create the file manually,
 via PCF or another build tool.  Just add a `catalog` section to the `src/main/resources/application.yml` file:
 
-The following feature flags are supported by the bucket & namespace.  All parameters are optional, and can be set at the service or plan level in the `service-settings` block.  Parameters are observed with the following precedence:  service-definition (in the catalog), plan and then in command-line parameters.  While buckets don't currently support service-settings or command-line parameters for retention & quotas, these will be added soon.
+The following feature flags are supported by the bucket & namespace.  All parameters are optional, and can be set at the service or plan level in the `service-settings` block.  Parameters are observed with the following precedence:  service-definition (in the catalog), plan and then in command-line parameters.  While buckets don't currently support service-settings or command-line parameters for retention, this will be added soon.
 
-| Resource          | Parameter           | Default Value  | Type       |  Description                                   |
-| :---------------- | :-------------------| :------------: | :--------- | :--------------------------------------------- |
-| bucket            | encrypted           | false          | Boolean    | Enable encryption of namespace                 |
-| bucket            | access-during-outage| false          | Boolean    | Enable potentially stale data during outage    |
-| bucket            | file-access         | false          | Boolean    | Enable file-access (NFS, HDFS) for bucket      |
-| bucket            | head-type           | s3             | String     | Specify object type (s3, swift) for bucket     |
-| bucket binding    | base-url            | -              | String     | Base URL name for object URI                   |
-| bucket binding    | use-ssl             | false          | Boolean    | Use SSL for object endpoint                    |
-| bucket binding    | permissions         | -              | JSON List  | List of permissions for user in bucket ACL     |
-| namespace         | domain-group-admins | -              | JSON List  | List of domain admins to be added to namespace |
-| namespace         | encrypted           | false          | Boolean    | Enable encryption of namespace                 |
-| namespace         | compliance-enabled  | false          | Boolean    | Enable compliance adhearance of retention      |
-| namespace         | access-during-outage| false          | Boolean    | Enable potentially stale data during outage    |
-| namespace         | default-bucket-quota| -1             | Integer    | Default quota applied to bucket (-1 for none)  |            
-| namespace         | quota*              | -              | JSON Object| Quota applied to namespace                     |            
-| namespace         | retention**         | -              | JSON Object| Retention policies applied to namespace        |            
-| namespace binding | base-url            | -              | String     | Base URL name for object URI                   |
-| namespace binding | use-ssl             | false          | Boolean    | Use SSL for object endpoint                    |
+| Resource          | Parameter           | Default Value  | Type     |  Description                                   |
+| :---------------- | :-------------------| :------------: | :------- | :--------------------------------------------- |
+| bucket            | encrypted           | false          | Boolean  | Enable encryption of namespace                 |
+| bucket            | access-during-outage| false          | Boolean  | Enable potentially stale data during outage    |
+| bucket            | file-access         | false          | Boolean  | Enable file-access (NFS, HDFS) for bucket      |
+| bucket            | head-type           | s3             | String   | Specify object type (s3, swift) for bucket     |
+| bucket            | quota*              | -              | JSON Map | Quota applied to bucket                        |            
+| bucket binding    | base-url            | -              | String   | Base URL name for object URI                   |
+| bucket binding    | use-ssl             | false          | Boolean  | Use SSL for object endpoint                    |
+| bucket binding    | permissions         | -              | JSON List| List of permissions for user in bucket ACL     |
+| namespace         | domain-group-admins | -              | JSON List| List of domain admins to be added to namespace |
+| namespace         | encrypted           | false          | Boolean  | Enable encryption of namespace                 |
+| namespace         | compliance-enabled  | false          | Boolean  | Enable compliance adhearance of retention      |
+| namespace         | access-during-outage| false          | Boolean  | Enable potentially stale data during outage    |
+| namespace         | default-bucket-quota| -1             | Integer  | Default quota applied to bucket (-1 for none)  |            
+| namespace         | quota*              | -              | JSON Map | Quota applied to namespace                     |            
+| namespace         | retention**         | -              | JSON Map | Retention policies applied to namespace        |            
+| namespace binding | base-url            | -              | String   | Base URL name for object URI                   |
+| namespace binding | use-ssl             | false          | Boolean  | Use SSL for object endpoint                    |
 
 \* Quotas are defined with the following format: `{quota: {limit: <int>, warn: <int>}}`
 

--- a/README.md
+++ b/README.md
@@ -126,25 +126,25 @@ via PCF or another build tool.  Just add a `catalog` section to the `src/main/re
 
 The following feature flags are supported by the bucket & namespace.  All parameters are optional, and can be set at the service or plan level in the `service-settings` block.  Parameters are observed with the following precedence:  service-definition (in the catalog), plan and then in command-line parameters.  While buckets don't currently support service-settings or command-line parameters for retention, this will be added soon.
 
-| Resource          | Parameter           | Default Value  | Type     |  Description                                   |
-| :---------------- | :-------------------| :------------: | :------- | :--------------------------------------------- |
-| bucket            | encrypted           | false          | Boolean  | Enable encryption of namespace                 |
-| bucket            | access-during-outage| false          | Boolean  | Enable potentially stale data during outage    |
-| bucket            | file-access         | false          | Boolean  | Enable file-access (NFS, HDFS) for bucket      |
-| bucket            | head-type           | s3             | String   | Specify object type (s3, swift) for bucket     |
-| bucket            | quota*              | -              | JSON Map | Quota applied to bucket                        |            
-| bucket binding    | base-url            | -              | String   | Base URL name for object URI                   |
-| bucket binding    | use-ssl             | false          | Boolean  | Use SSL for object endpoint                    |
-| bucket binding    | permissions         | -              | JSON List| List of permissions for user in bucket ACL     |
-| namespace         | domain-group-admins | -              | JSON List| List of domain admins to be added to namespace |
-| namespace         | encrypted           | false          | Boolean  | Enable encryption of namespace                 |
-| namespace         | compliance-enabled  | false          | Boolean  | Enable compliance adhearance of retention      |
-| namespace         | access-during-outage| false          | Boolean  | Enable potentially stale data during outage    |
-| namespace         | default-bucket-quota| -1             | Integer  | Default quota applied to bucket (-1 for none)  |            
-| namespace         | quota*              | -              | JSON Map | Quota applied to namespace                     |            
-| namespace         | retention**         | -              | JSON Map | Retention policies applied to namespace        |            
-| namespace binding | base-url            | -              | String   | Base URL name for object URI                   |
-| namespace binding | use-ssl             | false          | Boolean  | Use SSL for object endpoint                    |
+| Resource          | Parameter           | Default | Type     |  Description                                   |
+| :---------------- | :-------------------| :-----: | :------- | :--------------------------------------------- |
+| bucket            | encrypted           | false   | Boolean  | Enable encryption of namespace                 |
+| bucket            | access-during-outage| false   | Boolean  | Enable potentially stale data during outage    |
+| bucket            | file-access         | false   | Boolean  | Enable file-access (NFS, HDFS) for bucket      |
+| bucket            | head-type           | s3      | String   | Specify object type (s3, swift) for bucket     |
+| bucket            | quota*              | -       | JSON Map | Quota applied to bucket                        |            
+| bucket binding    | base-url            | -       | String   | Base URL name for object URI                   |
+| bucket binding    | use-ssl             | false   | Boolean  | Use SSL for object endpoint                    |
+| bucket binding    | permissions         | -       | JSON List| List of permissions for user in bucket ACL     |
+| namespace         | domain-group-admins | -       | JSON List| List of domain admins to be added to namespace |
+| namespace         | encrypted           | false   | Boolean  | Enable encryption of namespace                 |
+| namespace         | compliance-enabled  | false   | Boolean  | Enable compliance adhearance of retention      |
+| namespace         | access-during-outage| false   | Boolean  | Enable potentially stale data during outage    |
+| namespace         | default-bucket-quota| -1      | Integer  | Default quota applied to bucket (-1 for none)  |            
+| namespace         | quota*              | -       | JSON Map | Quota applied to namespace                     |            
+| namespace         | retention**         | -       | JSON Map | Retention policies applied to namespace        |            
+| namespace binding | base-url            | -       | String   | Base URL name for object URI                   |
+| namespace binding | use-ssl             | false   | Boolean  | Use SSL for object endpoint                    |
 
 \* Quotas are defined with the following format: `{quota: {limit: <int>, warn: <int>}}`
 

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsService.java
@@ -44,6 +44,7 @@ import com.emc.ecs.management.sdk.model.UserSecretKey;
 @Service
 public class EcsService {
 
+    private static final String UNCHECKED = "unchecked";
     private static final String WARN = "warn";
     private static final String LIMIT = "limit";
     private static final String QUOTA = "quota";
@@ -113,7 +114,7 @@ public class EcsService {
 		broker.getNamespace(), replicationGroupID, parameters));
 
 	if (parameters.containsKey(QUOTA)) {
-	    @SuppressWarnings("unchecked")
+	    @SuppressWarnings(UNCHECKED)
 	    Map<String, Integer> quota = (Map<String, Integer>) parameters
 		    .get(QUOTA);
 	    BucketQuotaAction.create(connection, prefix(id),
@@ -129,11 +130,11 @@ public class EcsService {
 		.orElse(new HashMap<>());
 	parameters.putAll(plan.getServiceSettings());
 	parameters.putAll(service.getServiceSettings());
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings(UNCHECKED)
 	Map<String, Object> quota = (Map<String, Object>) parameters
 		.getOrDefault("quota", new HashMap<>());
-	int limit = (int) quota.getOrDefault("limit", -1);
-	int warn = (int) quota.getOrDefault("warn", -1);
+	int limit = (int) quota.getOrDefault(LIMIT, -1);
+	int warn = (int) quota.getOrDefault(WARN, -1);
 
 	if (limit == -1 && warn == -1) {
 	    BucketQuotaAction.delete(connection, prefix(id),
@@ -321,7 +322,7 @@ public class EcsService {
 		replicationGroupID, parameters));
 
 	if (parameters.containsKey(QUOTA)) {
-	    @SuppressWarnings("unchecked")
+	    @SuppressWarnings(UNCHECKED)
 	    Map<String, Integer> quota = (Map<String, Integer>) parameters
 		    .get(QUOTA);
 	    NamespaceQuotaParam quotaParam = new NamespaceQuotaParam(id,
@@ -330,7 +331,7 @@ public class EcsService {
 	}
 
 	if (parameters.containsKey(RETENTION)) {
-	    @SuppressWarnings("unchecked")
+	    @SuppressWarnings(UNCHECKED)
 	    Map<String, Integer> retention = (Map<String, Integer>) parameters
 		    .get(RETENTION);
 	    for (Map.Entry<String, Integer> entry : retention.entrySet()) {
@@ -354,7 +355,7 @@ public class EcsService {
 		new NamespaceUpdate(parameters));
 
 	if (parameters.containsKey(RETENTION)) {
-	    @SuppressWarnings("unchecked")
+	    @SuppressWarnings(UNCHECKED)
 	    Map<String, Integer> retention = (Map<String, Integer>) parameters
 		    .get(RETENTION);
 	    for (Map.Entry<String, Integer> entry : retention.entrySet()) {

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsService.java
@@ -125,14 +125,22 @@ public class EcsService {
     public void changeBucketPlan(String id, ServiceDefinitionProxy service,
 	    PlanProxy plan, Optional<Map<String, Object>> maybeParameters)
 	    throws EcsManagementClientException {
-	int limit = plan.getQuotaLimit();
-	int warning = plan.getQuotaWarning();
-	if (limit == -1 && warning == -1) {
+	Map<String, Object> parameters = maybeParameters
+		.orElse(new HashMap<>());
+	parameters.putAll(plan.getServiceSettings());
+	parameters.putAll(service.getServiceSettings());
+	@SuppressWarnings("unchecked")
+	Map<String, Object> quota = (Map<String, Object>) parameters
+		.getOrDefault("quota", new HashMap<>());
+	int limit = (int) quota.getOrDefault("limit", -1);
+	int warn = (int) quota.getOrDefault("warn", -1);
+
+	if (limit == -1 && warn == -1) {
 	    BucketQuotaAction.delete(connection, prefix(id),
 		    broker.getNamespace());
 	} else {
 	    BucketQuotaAction.create(connection, prefix(id),
-		    broker.getNamespace(), limit, warning);
+		    broker.getNamespace(), limit, warn);
 	}
     }
 

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsService.java
@@ -120,7 +120,8 @@ public class EcsService {
     }
 
     public void changeBucketPlan(String id, ServiceDefinitionProxy service,
-	    PlanProxy plan) throws EcsManagementClientException {
+	    PlanProxy plan, Optional<Map<String, Object>> maybeParameters)
+	    throws EcsManagementClientException {
 	int limit = plan.getQuotaLimit();
 	int warning = plan.getQuotaWarning();
 	if (limit == -1 && warning == -1) {

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsService.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsService.java
@@ -44,6 +44,8 @@ import com.emc.ecs.management.sdk.model.UserSecretKey;
 @Service
 public class EcsService {
 
+    private static final String WARN = "warn";
+    private static final String LIMIT = "limit";
     private static final String QUOTA = "quota";
     private static final String RETENTION = "retention";
     private static final String SERVICE_NOT_FOUND = "No service matching service id: ";
@@ -110,13 +112,14 @@ public class EcsService {
 	BucketAction.create(connection, new ObjectBucketCreate(prefix(id),
 		broker.getNamespace(), replicationGroupID, parameters));
 
-	int limit = plan.getQuotaLimit();
-	int warning = plan.getQuotaWarning();
-
-	// no quota needed if neither is set
-	if (limit != -1 || warning != -1)
+	if (parameters.containsKey(QUOTA)) {
+	    @SuppressWarnings("unchecked")
+	    Map<String, Integer> quota = (Map<String, Integer>) parameters
+		    .get(QUOTA);
 	    BucketQuotaAction.create(connection, prefix(id),
-		    broker.getNamespace(), limit, warning);
+		    broker.getNamespace(), (int) quota.get(LIMIT),
+		    (int) quota.get(WARN));
+	}
     }
 
     public void changeBucketPlan(String id, ServiceDefinitionProxy service,
@@ -314,7 +317,7 @@ public class EcsService {
 	    Map<String, Integer> quota = (Map<String, Integer>) parameters
 		    .get(QUOTA);
 	    NamespaceQuotaParam quotaParam = new NamespaceQuotaParam(id,
-		    quota.get("limit"), quota.get("warn"));
+		    (int) quota.get(LIMIT), (int) quota.get(WARN));
 	    NamespaceQuotaAction.create(connection, prefix(id), quotaParam);
 	}
 

--- a/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceService.java
+++ b/src/main/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceService.java
@@ -61,7 +61,8 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
 	    String serviceType = (String) service.getServiceSettings()
 		    .get(SERVICE_TYPE);
 	    if (BUCKET.equals(serviceType)) {
-		ecs.createBucket(serviceInstanceId, service, plan);
+		ecs.createBucket(serviceInstanceId, service, plan,
+			Optional.ofNullable(request.getParameters()));
 	    } else if (NAMESPACE.equals(serviceType)) {
 		ecs.createNamespace(serviceInstanceId, service, plan,
 			Optional.ofNullable(request.getParameters()));
@@ -127,7 +128,8 @@ public class EcsServiceInstanceService implements ServiceInstanceService {
 		    .get(SERVICE_TYPE);
 	    PlanProxy plan = service.findPlan(planId);
 	    if (BUCKET.equals(serviceType)) {
-		ecs.changeBucketPlan(serviceInstanceId, service, plan);
+		ecs.changeBucketPlan(serviceInstanceId, service, plan,
+			Optional.ofNullable(params));
 	    } else if (NAMESPACE.equals(serviceType)) {
 		ecs.changeNamespacePlan(serviceInstanceId, service, plan,
 			params);

--- a/src/main/java/com/emc/ecs/management/sdk/BucketQuotaAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/BucketQuotaAction.java
@@ -35,8 +35,8 @@ public final class BucketQuotaAction {
 	UriBuilder uri = connection.getUriBuilder()
 		.segment(OBJECT, BUCKET, id, QUOTA)
 		.queryParam(NAMESPACE, namespace);
-	 Response response = connection.handleRemoteCall(GET, uri, null);
-	 return	response.readEntity(BucketQuotaDetails.class);
+	Response response = connection.handleRemoteCall(GET, uri, null);
+	return	response.readEntity(BucketQuotaDetails.class);
     }
 
 }

--- a/src/main/java/com/emc/ecs/management/sdk/BucketQuotaAction.java
+++ b/src/main/java/com/emc/ecs/management/sdk/BucketQuotaAction.java
@@ -2,9 +2,10 @@ package com.emc.ecs.management.sdk;
 
 import static com.emc.ecs.management.sdk.Constants.*;
 
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
-
 import com.emc.ecs.cloudfoundry.broker.EcsManagementClientException;
+import com.emc.ecs.management.sdk.model.BucketQuotaDetails;
 import com.emc.ecs.management.sdk.model.BucketQuotaParam;
 
 public final class BucketQuotaAction {
@@ -27,6 +28,15 @@ public final class BucketQuotaAction {
 		.segment(OBJECT, BUCKET, id, QUOTA)
 		.queryParam(NAMESPACE, namespace);
 	connection.handleRemoteCall(DELETE, uri, null);
+    }
+
+    public static BucketQuotaDetails get(Connection connection, String id,
+	    String namespace) throws EcsManagementClientException {
+	UriBuilder uri = connection.getUriBuilder()
+		.segment(OBJECT, BUCKET, id, QUOTA)
+		.queryParam(NAMESPACE, namespace);
+	 Response response = connection.handleRemoteCall(GET, uri, null);
+	 return	response.readEntity(BucketQuotaDetails.class);
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,8 +56,10 @@ catalog:
         - id: 09cac5b8-1b0a-11e6-b6ba-3e1d05defe78
           name: 5gb
           description: Free Trial
-          quota-limit: 5
-          quota-warning: 4
+          service-settings:
+            quota:
+              limit: 5
+              warning: 4
           metadata:
             costs:
               - amount:
@@ -73,14 +75,14 @@ catalog:
       description: Elastic Cloud S3 Object Storage Bucket
       bindable: true
       plan-updatable: true
-      head-type: s3
-      file-system-enabled: false
-      stale-allowed: true
       tags:
         - s3
         - bucket
       service-settings:
         service-type: bucket
+        head-type: s3
+        file-system-enabled: false
+        access-during-outage: true
       metadata:
         displayName: ecs-bucket
         imageUrl: http://www.emc.com/images/products/header-image-icon-ecs.png
@@ -92,8 +94,10 @@ catalog:
         - id: 8e777d49-0a78-4cf4-810a-b5f5173b019d
           name: 5gb
           description: Free Trial
-          quota-limit: 5
-          quota-warning: 4
+          service-settings:
+            quota:
+              limit: 5
+              warning: 4
           free: true
           metadata:
             costs:

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceServiceTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceInstanceServiceTest.java
@@ -59,7 +59,8 @@ public class EcsServiceInstanceServiceTest {
 
 	verify(repository).save(any(ServiceInstance.class));
 	verify(ecs, times(1)).createBucket(eq(BUCKET_NAME),
-		any(ServiceDefinitionProxy.class), any(PlanProxy.class));
+		any(ServiceDefinitionProxy.class), any(PlanProxy.class),
+		eq(Optional.ofNullable(params)));
     }
 
     /**
@@ -100,7 +101,8 @@ public class EcsServiceInstanceServiceTest {
 	verify(repository, times(1)).delete(BUCKET_NAME);
 	verify(repository, times(1)).save(any(ServiceInstance.class));
 	verify(ecs, times(1)).changeBucketPlan(eq(BUCKET_NAME),
-		any(ServiceDefinitionProxy.class), any(PlanProxy.class));
+		any(ServiceDefinitionProxy.class), any(PlanProxy.class),
+		eq(Optional.ofNullable(params)));
     }
 
     /**
@@ -120,8 +122,9 @@ public class EcsServiceInstanceServiceTest {
 	instSvc.createServiceInstance(namespaceCreateRequestFixture(params));
 
 	verify(repository).save(any(ServiceInstance.class));
-	verify(ecs, times(1)).createNamespace(eq(NAMESPACE), any(ServiceDefinitionProxy.class),
-		any(PlanProxy.class), eq(Optional.of(params)));
+	verify(ecs, times(1)).createNamespace(eq(NAMESPACE),
+		any(ServiceDefinitionProxy.class), any(PlanProxy.class),
+		eq(Optional.of(params)));
     }
 
     /**

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
@@ -50,6 +50,9 @@ import com.emc.ecs.management.sdk.model.RetentionClassUpdate;
 import com.emc.ecs.management.sdk.model.UserSecretKey;
 
 @RunWith(PowerMockRunner.class)
+@PrepareForTest({ ReplicationGroupAction.class, BucketAction.class,
+	ObjectUserAction.class, ObjectUserSecretAction.class,
+	BaseUrlAction.class, BucketQuotaAction.class })
 public class EcsServiceTest {
     private static final String BASE_URL = "base-url";
     private static final String USE_SSL = "use-ssl";
@@ -106,35 +109,12 @@ public class EcsServiceTest {
      * @throws EcsManagementClientException
      * @throws EcsManagementResourceNotFoundException
      */
-    @PrepareForTest({ ReplicationGroupAction.class, BucketAction.class,
-	    ObjectUserAction.class, ObjectUserSecretAction.class })
     @Test
     public void initializeStaticConfigTest()
 	    throws EcsManagementClientException,
 	    EcsManagementResourceNotFoundException {
+	setupInitTest();
 	when(broker.getObjectEndpoint()).thenReturn(OBJ_ENDPOINT);
-	PowerMockito.mockStatic(ReplicationGroupAction.class);
-
-	DataServiceReplicationGroup rg = new DataServiceReplicationGroup();
-	rg.setName(RG_NAME);
-	rg.setId(RG_ID);
-	PowerMockito.mockStatic(BucketAction.class);
-	when(BucketAction.exists(connection, REPO_BUCKET, NAMESPACE))
-		.thenReturn(true);
-
-	PowerMockito.mockStatic(ReplicationGroupAction.class);
-	when(ReplicationGroupAction.list(connection))
-		.thenReturn(Arrays.asList(rg));
-
-	PowerMockito.mockStatic(ObjectUserAction.class);
-	when(ObjectUserAction.exists(connection, REPO_USER, NAMESPACE))
-		.thenReturn(true);
-
-	UserSecretKey secretKey = new UserSecretKey();
-	secretKey.setSecretKey(TEST);
-	PowerMockito.mockStatic(ObjectUserSecretAction.class);
-	when(ObjectUserSecretAction.list(connection, REPO_USER))
-		.thenReturn(Arrays.asList(secretKey));
 
 	ecs.initialize();
 
@@ -152,50 +132,12 @@ public class EcsServiceTest {
      * @throws EcsManagementClientException
      * @throws EcsManagementResourceNotFoundException
      */
-    @PrepareForTest({ BaseUrlAction.class, ReplicationGroupAction.class,
-	    BucketAction.class, ObjectUserAction.class,
-	    ObjectUserSecretAction.class })
     @Test
     public void initializeBaseUrlLookup() throws EcsManagementClientException,
 	    EcsManagementResourceNotFoundException {
-	PowerMockito.mockStatic(ReplicationGroupAction.class);
-
+	setupInitTest();
+	setupBaseUrlTest(BASE_URL_NAME);
 	when(broker.getBaseUrl()).thenReturn(BASE_URL_NAME);
-
-	DataServiceReplicationGroup rg = new DataServiceReplicationGroup();
-	rg.setName(RG_NAME);
-	rg.setId(RG_ID);
-	PowerMockito.mockStatic(BucketAction.class);
-	when(BucketAction.exists(connection, REPO_BUCKET, NAMESPACE))
-		.thenReturn(true);
-
-	PowerMockito.mockStatic(ReplicationGroupAction.class);
-	when(ReplicationGroupAction.list(connection))
-		.thenReturn(Arrays.asList(rg));
-
-	PowerMockito.mockStatic(ObjectUserAction.class);
-	when(ObjectUserAction.exists(connection, REPO_USER, NAMESPACE))
-		.thenReturn(true);
-
-	PowerMockito.mockStatic(BaseUrlAction.class);
-	BaseUrl baseUrl = new BaseUrl();
-	baseUrl.setId(BASE_URL_ID);
-	baseUrl.setName(BASE_URL_NAME);
-	when(BaseUrlAction.list(same(connection)))
-		.thenReturn(Arrays.asList(baseUrl));
-
-	BaseUrlInfo baseUrlInfo = new BaseUrlInfo();
-	baseUrlInfo.setId(BASE_URL_ID);
-	baseUrlInfo.setName(BASE_URL_NAME);
-	baseUrlInfo.setBaseurl(BASE_URL);
-	when(BaseUrlAction.get(connection, BASE_URL_ID))
-		.thenReturn(baseUrlInfo);
-
-	UserSecretKey secretKey = new UserSecretKey();
-	secretKey.setSecretKey(TEST);
-	PowerMockito.mockStatic(ObjectUserSecretAction.class);
-	when(ObjectUserSecretAction.list(connection, REPO_USER))
-		.thenReturn(Arrays.asList(secretKey));
 
 	ecs.initialize();
 	String objEndpoint = new StringBuilder().append(HTTP).append(BASE_URL)
@@ -213,49 +155,14 @@ public class EcsServiceTest {
      * @throws EcsManagementClientException
      * @throws EcsManagementResourceNotFoundException
      */
-    @PrepareForTest({ BaseUrlAction.class, ReplicationGroupAction.class,
-	    BucketAction.class, ObjectUserAction.class,
-	    ObjectUserSecretAction.class })
     @Test
     public void initializeBaseUrlDefaultLookup()
 	    throws EcsManagementClientException,
 	    EcsManagementResourceNotFoundException {
 	PowerMockito.mockStatic(ReplicationGroupAction.class);
 
-	DataServiceReplicationGroup rg = new DataServiceReplicationGroup();
-	rg.setName(RG_NAME);
-	rg.setId(RG_ID);
-	PowerMockito.mockStatic(BucketAction.class);
-	when(BucketAction.exists(connection, REPO_BUCKET, NAMESPACE))
-		.thenReturn(true);
-
-	PowerMockito.mockStatic(ReplicationGroupAction.class);
-	when(ReplicationGroupAction.list(connection))
-		.thenReturn(Arrays.asList(rg));
-
-	PowerMockito.mockStatic(ObjectUserAction.class);
-	when(ObjectUserAction.exists(connection, REPO_USER, NAMESPACE))
-		.thenReturn(true);
-
-	PowerMockito.mockStatic(BaseUrlAction.class);
-	BaseUrl baseUrl = new BaseUrl();
-	baseUrl.setId(BASE_URL_ID);
-	baseUrl.setName(DEFAULT_BASE_URL_NAME);
-	when(BaseUrlAction.list(same(connection)))
-		.thenReturn(Arrays.asList(baseUrl));
-
-	BaseUrlInfo baseUrlInfo = new BaseUrlInfo();
-	baseUrlInfo.setId(BASE_URL_ID);
-	baseUrlInfo.setName(DEFAULT_BASE_URL_NAME);
-	baseUrlInfo.setBaseurl(BASE_URL);
-	when(BaseUrlAction.get(connection, BASE_URL_ID))
-		.thenReturn(baseUrlInfo);
-
-	UserSecretKey secretKey = new UserSecretKey();
-	secretKey.setSecretKey(TEST);
-	PowerMockito.mockStatic(ObjectUserSecretAction.class);
-	when(ObjectUserSecretAction.list(connection, REPO_USER))
-		.thenReturn(Arrays.asList(secretKey));
+	setupInitTest();
+	setupBaseUrlTest(DEFAULT_BASE_URL_NAME);
 
 	ecs.initialize();
 	String objEndpoint = new StringBuilder().append(HTTP).append(BASE_URL)
@@ -273,9 +180,6 @@ public class EcsServiceTest {
      * @throws EcsManagementClientException
      * @throws EcsManagementResourceNotFoundException
      */
-    @PrepareForTest({ BaseUrlAction.class, ReplicationGroupAction.class,
-	    BucketAction.class, ObjectUserAction.class,
-	    ObjectUserSecretAction.class })
     @Test(expected = EcsManagementClientException.class)
     public void initializeBaseUrlDefaultLookupFails()
 	    throws EcsManagementClientException,
@@ -294,7 +198,6 @@ public class EcsServiceTest {
      * 
      * @throws Exception
      */
-    @PrepareForTest({ BucketAction.class, BucketQuotaAction.class })
     @Test
     public void createBucketDefaultTest() throws Exception {
 	PowerMockito.mockStatic(BucketAction.class);
@@ -332,7 +235,6 @@ public class EcsServiceTest {
      * 
      * @throws Exception
      */
-    @PrepareForTest({ BucketAction.class, BucketQuotaAction.class })
     @Test
     public void createBucketWithoutParamsTest() throws Exception {
 	PowerMockito.mockStatic(BucketAction.class);
@@ -374,7 +276,6 @@ public class EcsServiceTest {
      * 
      * @throws Exception
      */
-    @PrepareForTest({ BucketAction.class, BucketQuotaAction.class })
     @Test
     public void createBucketWithParamsTest() throws Exception {
 	Map<String, Object> params = new HashMap<>();
@@ -420,7 +321,6 @@ public class EcsServiceTest {
      * 
      * @throws Exception
      */
-    @PrepareForTest({ BucketAction.class, BucketQuotaAction.class })
     @Test
     public void changeBucketPlanTestNoQuota() throws Exception {
 	PowerMockito.mockStatic(BucketQuotaAction.class);
@@ -448,7 +348,6 @@ public class EcsServiceTest {
      * 
      * @throws Exception
      */
-    @PrepareForTest({ BucketAction.class, BucketQuotaAction.class })
     @Test
     public void changeBucketPlanTestParametersQuota() throws Exception {
 	PowerMockito.mockStatic(BucketQuotaAction.class);
@@ -488,7 +387,6 @@ public class EcsServiceTest {
      * 
      * @throws Exception
      */
-    @PrepareForTest({ BucketAction.class, BucketQuotaAction.class })
     @Test
     public void changeBucketPlanTestParametersIgnoredQuota() throws Exception {
 	PowerMockito.mockStatic(BucketQuotaAction.class);
@@ -528,7 +426,6 @@ public class EcsServiceTest {
      * 
      * @throws Exception
      */
-    @PrepareForTest({ BucketAction.class, BucketQuotaAction.class })
     @Test
     public void changeBucketPlanTestNewQuota() throws Exception {
 	PowerMockito.mockStatic(BucketQuotaAction.class);
@@ -1222,5 +1119,45 @@ public class EcsServiceTest {
 		.append(DOT).append(BASE_URL).append(_9021).toString();
 	assertEquals(expectedURl, ecs.getNamespaceURL(NAMESPACE, service, plan,
 		Optional.ofNullable(params)));
+    }
+
+    private void setupInitTest() throws EcsManagementClientException {
+	DataServiceReplicationGroup rg = new DataServiceReplicationGroup();
+	rg.setName(RG_NAME);
+	rg.setId(RG_ID);
+	UserSecretKey secretKey = new UserSecretKey();
+	
+	secretKey.setSecretKey(TEST);
+	PowerMockito.mockStatic(BucketAction.class);
+	when(BucketAction.exists(connection, REPO_BUCKET, NAMESPACE))
+		.thenReturn(true);
+
+	PowerMockito.mockStatic(ReplicationGroupAction.class);
+	when(ReplicationGroupAction.list(connection))
+		.thenReturn(Arrays.asList(rg));
+
+	PowerMockito.mockStatic(ObjectUserAction.class);
+	when(ObjectUserAction.exists(connection, REPO_USER, NAMESPACE))
+		.thenReturn(true);
+
+	PowerMockito.mockStatic(ObjectUserSecretAction.class);
+	when(ObjectUserSecretAction.list(connection, REPO_USER))
+		.thenReturn(Arrays.asList(secretKey));
+    }
+
+    private void setupBaseUrlTest(String name) throws EcsManagementClientException {
+	PowerMockito.mockStatic(BaseUrlAction.class);
+	BaseUrl baseUrl = new BaseUrl();
+	baseUrl.setId(BASE_URL_ID);
+	baseUrl.setName(name);
+	when(BaseUrlAction.list(same(connection)))
+		.thenReturn(Arrays.asList(baseUrl));
+
+	BaseUrlInfo baseUrlInfo = new BaseUrlInfo();
+	baseUrlInfo.setId(BASE_URL_ID);
+	baseUrlInfo.setName(name);
+	baseUrlInfo.setBaseurl(BASE_URL);
+	when(BaseUrlAction.get(connection, BASE_URL_ID))
+		.thenReturn(baseUrlInfo);
     }
 }

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
@@ -447,7 +447,7 @@ public class EcsServiceTest {
     }
 
     /**
-     * A services must be able to remove a user from a bucket
+     * A service must be able to remove a user from a bucket.
      * 
      * @throws Exception
      */
@@ -481,6 +481,17 @@ public class EcsServiceTest {
 	List<BucketUserAcl> actualUserAcl = aclCaptor.getValue().getAcl()
 		.getUserAccessList();
 	assertFalse(actualUserAcl.contains(userAcl));
+    }
+
+    /**
+     * A service must be able to delete a user.
+     * @throws EcsManagementClientException 
+     */
+    public void deleteUser() throws EcsManagementClientException {
+	PowerMockito.mockStatic(ObjectUserAction.class);
+	ecs.deleteUser(USER1);
+	PowerMockito.verifyStatic();
+	ObjectUserAction.delete(same(connection), eq(PREFIX + USER1));
     }
 
     /**

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -87,6 +88,15 @@ public class EcsServiceTest {
     @Autowired
     @InjectMocks
     private EcsService ecs;
+    
+    @Before
+    public void setUp() {
+	when(broker.getPrefix()).thenReturn(PREFIX);
+	when(broker.getReplicationGroup()).thenReturn(RG_NAME);
+	when(broker.getNamespace()).thenReturn(NAMESPACE);
+	when(broker.getRepositoryUser()).thenReturn(USER);
+	when(broker.getRepositoryBucket()).thenReturn(REPOSITORY);
+    }
 
     /**
      * When initializing the ecs-service, and object-endpoint, repo-user &
@@ -102,14 +112,8 @@ public class EcsServiceTest {
     public void initializeStaticConfigTest()
 	    throws EcsManagementClientException,
 	    EcsManagementResourceNotFoundException {
-	PowerMockito.mockStatic(ReplicationGroupAction.class);
-
 	when(broker.getObjectEndpoint()).thenReturn(OBJ_ENDPOINT);
-	when(broker.getPrefix()).thenReturn(PREFIX);
-	when(broker.getReplicationGroup()).thenReturn(RG_NAME);
-	when(broker.getNamespace()).thenReturn(NAMESPACE);
-	when(broker.getRepositoryUser()).thenReturn(USER);
-	when(broker.getRepositoryBucket()).thenReturn(REPOSITORY);
+	PowerMockito.mockStatic(ReplicationGroupAction.class);
 
 	DataServiceReplicationGroup rg = new DataServiceReplicationGroup();
 	rg.setName(RG_NAME);
@@ -157,11 +161,6 @@ public class EcsServiceTest {
 	PowerMockito.mockStatic(ReplicationGroupAction.class);
 
 	when(broker.getBaseUrl()).thenReturn(BASE_URL_NAME);
-	when(broker.getPrefix()).thenReturn(PREFIX);
-	when(broker.getReplicationGroup()).thenReturn(RG_NAME);
-	when(broker.getNamespace()).thenReturn(NAMESPACE);
-	when(broker.getRepositoryUser()).thenReturn(USER);
-	when(broker.getRepositoryBucket()).thenReturn(REPOSITORY);
 
 	DataServiceReplicationGroup rg = new DataServiceReplicationGroup();
 	rg.setName(RG_NAME);
@@ -222,12 +221,6 @@ public class EcsServiceTest {
 	    throws EcsManagementClientException,
 	    EcsManagementResourceNotFoundException {
 	PowerMockito.mockStatic(ReplicationGroupAction.class);
-
-	when(broker.getPrefix()).thenReturn(PREFIX);
-	when(broker.getReplicationGroup()).thenReturn(RG_NAME);
-	when(broker.getNamespace()).thenReturn(NAMESPACE);
-	when(broker.getRepositoryUser()).thenReturn(USER);
-	when(broker.getRepositoryBucket()).thenReturn(REPOSITORY);
 
 	DataServiceReplicationGroup rg = new DataServiceReplicationGroup();
 	rg.setName(RG_NAME);
@@ -313,8 +306,6 @@ public class EcsServiceTest {
 		eq(5), eq(4));
 	ServiceDefinitionProxy service = bucketServiceFixture();
 	PlanProxy plan = service.findPlan(BUCKET_PLAN_ID1);
-	when(broker.getPrefix()).thenReturn(PREFIX);
-	when(broker.getNamespace()).thenReturn(NAMESPACE);
 
 	Map<String, Object> params = new HashMap<>();
 	ecs.createBucket(BUCKET_NAME, service, plan, Optional.of(params));
@@ -352,8 +343,6 @@ public class EcsServiceTest {
 
 	ServiceDefinitionProxy service = bucketServiceFixture();
 	PlanProxy plan = service.findPlan(BUCKET_PLAN_ID2);
-	when(broker.getPrefix()).thenReturn(PREFIX);
-	when(broker.getNamespace()).thenReturn(NAMESPACE);
 	when(catalog.findServiceDefinition(BUCKET_SERVICE_ID))
 		.thenReturn(service);
 
@@ -405,8 +394,6 @@ public class EcsServiceTest {
 		eq(10), eq(9));
 	ServiceDefinitionProxy service = bucketServiceFixture();
 	PlanProxy plan = service.findPlan(BUCKET_PLAN_ID1);
-	when(broker.getPrefix()).thenReturn(PREFIX);
-	when(broker.getNamespace()).thenReturn(NAMESPACE);
 
 	ecs.createBucket(BUCKET_NAME, service, plan, Optional.of(params));
 
@@ -439,8 +426,6 @@ public class EcsServiceTest {
 	PowerMockito.mockStatic(BucketQuotaAction.class);
 	PowerMockito.doNothing().when(BucketQuotaAction.class, DELETE,
 		same(connection), eq(BUCKET_NAME), eq(NAMESPACE));
-	when(broker.getPrefix()).thenReturn(PREFIX);
-	when(broker.getNamespace()).thenReturn(NAMESPACE);
 	ServiceDefinitionProxy service = bucketServiceFixture();
 	PlanProxy plan = service.findPlan(BUCKET_PLAN_ID2);
 
@@ -469,8 +454,6 @@ public class EcsServiceTest {
 	PowerMockito.mockStatic(BucketQuotaAction.class);
 	PowerMockito.doNothing().when(BucketQuotaAction.class, CREATE,
 		same(connection), eq(BUCKET_NAME), eq(NAMESPACE), eq(5), eq(4));
-	when(broker.getPrefix()).thenReturn(PREFIX);
-	when(broker.getNamespace()).thenReturn(NAMESPACE);
 	ServiceDefinitionProxy service = bucketServiceFixture();
 	PlanProxy plan = service.findPlan(BUCKET_PLAN_ID2);
 	Map<String, Object> quota = new HashMap<>();
@@ -511,8 +494,6 @@ public class EcsServiceTest {
 	PowerMockito.mockStatic(BucketQuotaAction.class);
 	PowerMockito.doNothing().when(BucketQuotaAction.class, CREATE,
 		same(connection), eq(BUCKET_NAME), eq(NAMESPACE), eq(5), eq(4));
-	when(broker.getPrefix()).thenReturn(PREFIX);
-	when(broker.getNamespace()).thenReturn(NAMESPACE);
 	ServiceDefinitionProxy service = bucketServiceFixture();
 	PlanProxy plan = service.findPlan(BUCKET_PLAN_ID1);
 	Map<String, Object> quota = new HashMap<>();
@@ -553,8 +534,6 @@ public class EcsServiceTest {
 	PowerMockito.mockStatic(BucketQuotaAction.class);
 	PowerMockito.doNothing().when(BucketQuotaAction.class, CREATE,
 		same(connection), eq(BUCKET_NAME), eq(NAMESPACE), eq(5), eq(4));
-	when(broker.getPrefix()).thenReturn(PREFIX);
-	when(broker.getNamespace()).thenReturn(NAMESPACE);
 	ServiceDefinitionProxy service = bucketServiceFixture();
 	PlanProxy plan = service.findPlan(BUCKET_PLAN_ID1);
 
@@ -603,8 +582,6 @@ public class EcsServiceTest {
 	ArgumentCaptor<NamespaceUpdate> updateCaptor = ArgumentCaptor
 		.forClass(NamespaceUpdate.class);
 
-	when(broker.getPrefix()).thenReturn(PREFIX);
-
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	PlanProxy plan = service.findPlan(NAMESPACE_PLAN_ID1);
 	ecs.changeNamespacePlan(NAMESPACE, service, plan, params);
@@ -639,7 +616,6 @@ public class EcsServiceTest {
 		same(connection), anyString(), any(NamespaceQuotaParam.class));
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	PlanProxy plan = service.getPlans().get(0);
-	when(broker.getPrefix()).thenReturn(PREFIX);
 
 	Map<String, Object> params = new HashMap<>();
 	ecs.createNamespace(NAMESPACE, namespaceServiceFixture(), plan,
@@ -686,7 +662,6 @@ public class EcsServiceTest {
 	ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
 	ArgumentCaptor<NamespaceUpdate> updateCaptor = ArgumentCaptor
 		.forClass(NamespaceUpdate.class);
-	when(broker.getPrefix()).thenReturn(PREFIX);
 
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	PlanProxy plan = service.findPlan(NAMESPACE_PLAN_ID2);
@@ -724,7 +699,6 @@ public class EcsServiceTest {
 		same(connection), anyString(), any(NamespaceQuotaParam.class));
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	PlanProxy plan = service.getPlans().get(0);
-	when(broker.getPrefix()).thenReturn(PREFIX);
 	when(catalog.findServiceDefinition(NAMESPACE_SERVICE_ID))
 		.thenReturn(service);
 
@@ -781,7 +755,6 @@ public class EcsServiceTest {
 		same(connection), anyString(), any(NamespaceQuotaParam.class));
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	PlanProxy plan = service.getPlans().get(0);
-	when(broker.getPrefix()).thenReturn(PREFIX);
 	when(catalog.findServiceDefinition(NAMESPACE_SERVICE_ID))
 		.thenReturn(service);
 
@@ -833,8 +806,6 @@ public class EcsServiceTest {
 	ArgumentCaptor<NamespaceUpdate> updateCaptor = ArgumentCaptor
 		.forClass(NamespaceUpdate.class);
 
-	when(broker.getPrefix()).thenReturn(PREFIX);
-
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	PlanProxy plan = service.findPlan(NAMESPACE_PLAN_ID1);
 	ecs.changeNamespacePlan(NAMESPACE, service, plan, params);
@@ -872,7 +843,6 @@ public class EcsServiceTest {
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	PlanProxy plan = service.getPlans().get(2);
 
-	when(broker.getPrefix()).thenReturn(PREFIX);
 	when(catalog.findServiceDefinition(NAMESPACE_SERVICE_ID))
 		.thenReturn(namespaceServiceFixture());
 
@@ -928,8 +898,6 @@ public class EcsServiceTest {
 	ArgumentCaptor<RetentionClassCreate> createCaptor = ArgumentCaptor
 		.forClass(RetentionClassCreate.class);
 
-	when(broker.getPrefix()).thenReturn(PREFIX);
-
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	PlanProxy plan = service.findPlan(NAMESPACE_PLAN_ID2);
 	ecs.changeNamespacePlan(NAMESPACE, service, plan, params);
@@ -968,8 +936,6 @@ public class EcsServiceTest {
 		same(connection), anyString(), anyString());
 	ArgumentCaptor<String> nsCaptor = ArgumentCaptor.forClass(String.class);
 	ArgumentCaptor<String> rcCaptor = ArgumentCaptor.forClass(String.class);
-
-	when(broker.getPrefix()).thenReturn(PREFIX);
 
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	PlanProxy plan = service.findPlan(NAMESPACE_PLAN_ID2);
@@ -1013,8 +979,6 @@ public class EcsServiceTest {
 	ArgumentCaptor<RetentionClassUpdate> updateCaptor = ArgumentCaptor
 		.forClass(RetentionClassUpdate.class);
 
-	when(broker.getPrefix()).thenReturn(PREFIX);
-
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	PlanProxy plan = service.findPlan(NAMESPACE_PLAN_ID2);
 	ecs.changeNamespacePlan(NAMESPACE, service, plan, params);
@@ -1038,7 +1002,6 @@ public class EcsServiceTest {
 	PowerMockito.mockStatic(NamespaceAction.class);
 	PowerMockito.doNothing().when(NamespaceAction.class, DELETE,
 		same(connection), anyString());
-	when(broker.getPrefix()).thenReturn(PREFIX);
 
 	ecs.deleteNamespace(NAMESPACE);
 
@@ -1068,8 +1031,6 @@ public class EcsServiceTest {
 		.when(ObjectUserSecretAction.class, "list", same(connection),
 			anyString())
 		.thenReturn(Arrays.asList(new UserSecretKey()));
-
-	when(broker.getPrefix()).thenReturn(PREFIX);
 
 	ecs.createUser(USER1, NAMESPACE);
 

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
@@ -28,7 +28,6 @@ import com.emc.ecs.cloudfoundry.broker.config.CatalogConfig;
 import com.emc.ecs.cloudfoundry.broker.model.NamespaceQuotaParam;
 import com.emc.ecs.cloudfoundry.broker.model.PlanProxy;
 import com.emc.ecs.cloudfoundry.broker.model.ServiceDefinitionProxy;
-import com.emc.ecs.cloudfoundry.broker.service.EcsService;
 import com.emc.ecs.management.sdk.BaseUrlAction;
 import com.emc.ecs.management.sdk.BucketAction;
 import com.emc.ecs.management.sdk.BucketQuotaAction;
@@ -51,7 +50,16 @@ import com.emc.ecs.management.sdk.model.UserSecretKey;
 
 @RunWith(PowerMockRunner.class)
 public class EcsServiceTest {
-
+    private static final String BASE_URL = "base-url";
+    private static final String USE_SSL = "use-ssl";
+    private static final String USER1 = "user1";
+    private static final String EXISTS = "exists";
+    private static final String DEFAULT_BUCKET_QUOTA = "default-bucket-quota";
+    private static final String DOMAIN_GROUP_ADMINS = "domain-group-admins";
+    private static final String ACCESS_DURING_OUTAGE = "access-during-outage";
+    private static final String ENCRYPTED = "encrypted";
+    private static final String REPOSITORY = "repository";
+    private static final String USER = "user";
     private static final String WARN = "warn";
     private static final String QUOTA = "quota";
     private static final String LIMIT = "limit";
@@ -100,8 +108,8 @@ public class EcsServiceTest {
 	when(broker.getPrefix()).thenReturn(PREFIX);
 	when(broker.getReplicationGroup()).thenReturn(RG_NAME);
 	when(broker.getNamespace()).thenReturn(NAMESPACE);
-	when(broker.getRepositoryUser()).thenReturn("user");
-	when(broker.getRepositoryBucket()).thenReturn("repository");
+	when(broker.getRepositoryUser()).thenReturn(USER);
+	when(broker.getRepositoryBucket()).thenReturn(REPOSITORY);
 
 	DataServiceReplicationGroup rg = new DataServiceReplicationGroup();
 	rg.setName(RG_NAME);
@@ -152,8 +160,8 @@ public class EcsServiceTest {
 	when(broker.getPrefix()).thenReturn(PREFIX);
 	when(broker.getReplicationGroup()).thenReturn(RG_NAME);
 	when(broker.getNamespace()).thenReturn(NAMESPACE);
-	when(broker.getRepositoryUser()).thenReturn("user");
-	when(broker.getRepositoryBucket()).thenReturn("repository");
+	when(broker.getRepositoryUser()).thenReturn(USER);
+	when(broker.getRepositoryBucket()).thenReturn(REPOSITORY);
 
 	DataServiceReplicationGroup rg = new DataServiceReplicationGroup();
 	rg.setName(RG_NAME);
@@ -218,8 +226,8 @@ public class EcsServiceTest {
 	when(broker.getPrefix()).thenReturn(PREFIX);
 	when(broker.getReplicationGroup()).thenReturn(RG_NAME);
 	when(broker.getNamespace()).thenReturn(NAMESPACE);
-	when(broker.getRepositoryUser()).thenReturn("user");
-	when(broker.getRepositoryBucket()).thenReturn("repository");
+	when(broker.getRepositoryUser()).thenReturn(USER);
+	when(broker.getRepositoryBucket()).thenReturn(REPOSITORY);
 
 	DataServiceReplicationGroup rg = new DataServiceReplicationGroup();
 	rg.setName(RG_NAME);
@@ -381,8 +389,8 @@ public class EcsServiceTest {
     @Test
     public void createBucketWithParamsTest() throws Exception {
 	Map<String, Object> params = new HashMap<>();
-	params.put("encrypted", true);
-	params.put("access-during-outage", true);
+	params.put(ENCRYPTED, true);
+	params.put(ACCESS_DURING_OUTAGE, true);
 	Map<String, Object> quota = new HashMap<>();
 	quota.put(WARN, 9);
 	quota.put(LIMIT, 10);
@@ -582,11 +590,11 @@ public class EcsServiceTest {
     @Test
     public void changeBucketPlanWithParamsTest() throws Exception {
 	Map<String, Object> params = new HashMap<>();
-	params.put("domain-group-admins", EXTERNAL_ADMIN);
-	params.put("encrypted", true);
+	params.put(DOMAIN_GROUP_ADMINS, EXTERNAL_ADMIN);
+	params.put(ENCRYPTED, true);
 	params.put("compliance-enabled", true);
-	params.put("access-during-outage", true);
-	params.put("default-bucket-quota", 10);
+	params.put(ACCESS_DURING_OUTAGE, true);
+	params.put(DEFAULT_BUCKET_QUOTA, 10);
 
 	PowerMockito.mockStatic(NamespaceAction.class);
 	PowerMockito.doNothing().when(NamespaceAction.class, UPDATE,
@@ -756,11 +764,11 @@ public class EcsServiceTest {
     @Test
     public void createNamespaceWithParamsTest() throws Exception {
 	Map<String, Object> params = new HashMap<>();
-	params.put("domain-group-admins", EXTERNAL_ADMIN);
-	params.put("encrypted", true);
+	params.put(DOMAIN_GROUP_ADMINS, EXTERNAL_ADMIN);
+	params.put(ENCRYPTED, true);
 	params.put("compliance-enabled", true);
-	params.put("access-during-outage", true);
-	params.put("default-bucket-quota", 10);
+	params.put(ACCESS_DURING_OUTAGE, true);
+	params.put(DEFAULT_BUCKET_QUOTA, 10);
 
 	PowerMockito.mockStatic(NamespaceAction.class);
 	PowerMockito.doNothing().when(NamespaceAction.class, CREATE,
@@ -812,11 +820,11 @@ public class EcsServiceTest {
     @Test
     public void changeNamespacePlanWithParamsTest() throws Exception {
 	Map<String, Object> params = new HashMap<>();
-	params.put("domain-group-admins", EXTERNAL_ADMIN);
-	params.put("encrypted", true);
+	params.put(DOMAIN_GROUP_ADMINS, EXTERNAL_ADMIN);
+	params.put(ENCRYPTED, true);
 	params.put("compliance-enabled", true);
-	params.put("access-during-outage", true);
-	params.put("default-bucket-quota", 10);
+	params.put(ACCESS_DURING_OUTAGE, true);
+	params.put(DEFAULT_BUCKET_QUOTA, 10);
 
 	PowerMockito.mockStatic(NamespaceAction.class);
 	PowerMockito.doNothing().when(NamespaceAction.class, UPDATE,
@@ -881,8 +889,8 @@ public class EcsServiceTest {
 	assertTrue(create.getIsComplianceEnabled());
 
 	PowerMockito.verifyStatic();
-	ArgumentCaptor<RetentionClassCreate> retentionCreateCaptor = ArgumentCaptor
-		.forClass(RetentionClassCreate.class);
+	ArgumentCaptor<RetentionClassCreate> retentionCreateCaptor =
+		ArgumentCaptor.forClass(RetentionClassCreate.class);
 	ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
 	NamespaceRetentionAction.create(same(connection), idCaptor.capture(),
 		retentionCreateCaptor.capture());
@@ -911,7 +919,7 @@ public class EcsServiceTest {
 		same(connection), anyString(), any(NamespaceUpdate.class));
 
 	PowerMockito.mockStatic(NamespaceRetentionAction.class);
-	PowerMockito.when(NamespaceRetentionAction.class, "exists",
+	PowerMockito.when(NamespaceRetentionAction.class, EXISTS,
 		same(connection), anyString(), any(RetentionClassUpdate.class))
 		.thenReturn(false);
 	PowerMockito.doNothing().when(NamespaceRetentionAction.class, CREATE,
@@ -953,7 +961,7 @@ public class EcsServiceTest {
 		same(connection), anyString(), any(NamespaceUpdate.class));
 
 	PowerMockito.mockStatic(NamespaceRetentionAction.class);
-	PowerMockito.when(NamespaceRetentionAction.class, "exists",
+	PowerMockito.when(NamespaceRetentionAction.class, EXISTS,
 		same(connection), anyString(), any(RetentionClassUpdate.class))
 		.thenReturn(true);
 	PowerMockito.doNothing().when(NamespaceRetentionAction.class, DELETE,
@@ -994,7 +1002,7 @@ public class EcsServiceTest {
 		same(connection), anyString(), any(NamespaceUpdate.class));
 
 	PowerMockito.mockStatic(NamespaceRetentionAction.class);
-	PowerMockito.when(NamespaceRetentionAction.class, "exists",
+	PowerMockito.when(NamespaceRetentionAction.class, EXISTS,
 		same(connection), anyString(), any(RetentionClassUpdate.class))
 		.thenReturn(true);
 	PowerMockito.doNothing().when(NamespaceRetentionAction.class, UPDATE,
@@ -1063,7 +1071,7 @@ public class EcsServiceTest {
 
 	when(broker.getPrefix()).thenReturn(PREFIX);
 
-	ecs.createUser("user1", NAMESPACE);
+	ecs.createUser(USER1, NAMESPACE);
 
 	ArgumentCaptor<String> nsCaptor = ArgumentCaptor.forClass(String.class);
 	ArgumentCaptor<String> userCaptor = ArgumentCaptor
@@ -1072,7 +1080,7 @@ public class EcsServiceTest {
 	ObjectUserAction.create(same(connection), userCaptor.capture(),
 		nsCaptor.capture());
 	assertEquals(PREFIX + NAMESPACE, nsCaptor.getValue());
-	assertEquals(PREFIX + "user1", userCaptor.getValue());
+	assertEquals(PREFIX + USER1, userCaptor.getValue());
     }
 
     /**
@@ -1149,7 +1157,7 @@ public class EcsServiceTest {
 	    throws EcsManagementClientException {
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	Map<String, Object> serviceSettings = service.getServiceSettings();
-	serviceSettings.put("use-ssl", true);
+	serviceSettings.put(USE_SSL, true);
 	service.setServiceSettings(serviceSettings);
 
 	PlanProxy plan = service.findPlan(NAMESPACE_PLAN_ID1);
@@ -1188,7 +1196,7 @@ public class EcsServiceTest {
     public void testNamespaceURLNoSSLParamBaseURL()
 	    throws EcsManagementClientException {
 	HashMap<String, Object> params = new HashMap<>();
-	params.put("base-url", BASE_URL_NAME);
+	params.put(BASE_URL, BASE_URL_NAME);
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	PlanProxy plan = service.findPlan(NAMESPACE_PLAN_ID1);
 
@@ -1225,10 +1233,10 @@ public class EcsServiceTest {
     public void testNamespaceURLSSLParamBaseURL()
 	    throws EcsManagementClientException {
 	HashMap<String, Object> params = new HashMap<>();
-	params.put("base-url", BASE_URL_NAME);
+	params.put(BASE_URL, BASE_URL_NAME);
 	ServiceDefinitionProxy service = namespaceServiceFixture();
 	Map<String, Object> serviceSettings = service.getServiceSettings();
-	serviceSettings.put("use-ssl", true);
+	serviceSettings.put(USE_SSL, true);
 	service.setServiceSettings(serviceSettings);
 
 	PlanProxy plan = service.findPlan(NAMESPACE_PLAN_ID1);

--- a/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
+++ b/src/test/java/com/emc/ecs/cloudfoundry/broker/service/EcsServiceTest.java
@@ -52,6 +52,9 @@ import com.emc.ecs.management.sdk.model.UserSecretKey;
 @RunWith(PowerMockRunner.class)
 public class EcsServiceTest {
 
+    private static final String WARN = "warn";
+    private static final String QUOTA = "quota";
+    private static final String LIMIT = "limit";
     private static final String DOT = ".";
     private static final String HTTPS = "https://";
     private static final int THIRTY_DAYS_IN_SEC = 2592000;
@@ -381,9 +384,9 @@ public class EcsServiceTest {
 	params.put("encrypted", true);
 	params.put("access-during-outage", true);
 	Map<String, Object> quota = new HashMap<>();
-	quota.put("warn", 9);
-	quota.put("limit", 10);
-	params.put("quota", quota);
+	quota.put(WARN, 9);
+	quota.put(LIMIT, 10);
+	params.put(QUOTA, quota);
 
 	PowerMockito.mockStatic(BucketAction.class);
 	PowerMockito.doNothing().when(BucketAction.class, CREATE,
@@ -463,10 +466,10 @@ public class EcsServiceTest {
 	ServiceDefinitionProxy service = bucketServiceFixture();
 	PlanProxy plan = service.findPlan(BUCKET_PLAN_ID2);
 	Map<String, Object> quota = new HashMap<>();
-	quota.put("limit", 100);
-	quota.put("warn", 80);
+	quota.put(LIMIT, 100);
+	quota.put(WARN, 80);
 	Map<String, Object> params = new HashMap<>();
-	params.put("quota", quota);
+	params.put(QUOTA, quota);
 
 	ecs.changeBucketPlan(BUCKET_NAME, service, plan,
 		Optional.ofNullable(params));
@@ -505,10 +508,10 @@ public class EcsServiceTest {
 	ServiceDefinitionProxy service = bucketServiceFixture();
 	PlanProxy plan = service.findPlan(BUCKET_PLAN_ID1);
 	Map<String, Object> quota = new HashMap<>();
-	quota.put("limit", 100);
-	quota.put("warn", 80);
+	quota.put(LIMIT, 100);
+	quota.put(WARN, 80);
 	Map<String, Object> params = new HashMap<>();
-	params.put("quota", quota);
+	params.put(QUOTA, quota);
 
 	ecs.changeBucketPlan(BUCKET_NAME, service, plan,
 		Optional.ofNullable(params));
@@ -953,7 +956,7 @@ public class EcsServiceTest {
 	PowerMockito.when(NamespaceRetentionAction.class, "exists",
 		same(connection), anyString(), any(RetentionClassUpdate.class))
 		.thenReturn(true);
-	PowerMockito.doNothing().when(NamespaceRetentionAction.class, "delete",
+	PowerMockito.doNothing().when(NamespaceRetentionAction.class, DELETE,
 		same(connection), anyString(), anyString());
 	ArgumentCaptor<String> nsCaptor = ArgumentCaptor.forClass(String.class);
 	ArgumentCaptor<String> rcCaptor = ArgumentCaptor.forClass(String.class);
@@ -1025,7 +1028,7 @@ public class EcsServiceTest {
     @Test
     public void deleteNamespace() throws Exception {
 	PowerMockito.mockStatic(NamespaceAction.class);
-	PowerMockito.doNothing().when(NamespaceAction.class, "delete",
+	PowerMockito.doNothing().when(NamespaceAction.class, DELETE,
 		same(connection), anyString());
 	when(broker.getPrefix()).thenReturn(PREFIX);
 

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -71,10 +71,14 @@ public class Fixtures {
 	/*
 	 * Plan 1: 5gb quota with 4gb notification
 	 */
+	Map<String, Object> settings1 = new HashMap<>();
+	Map<String, Object> quota = new HashMap<>();
+	quota.put("limit", 5);
+	quota.put("warn", 4);
+	settings1.put("quota", quota);
 	PlanProxy bucketPlan1 = new PlanProxy(BUCKET_PLAN_ID1, _5GB,
 		FREE_TRIAL, null, true);
-	bucketPlan1.setQuotaLimit(5);
-	bucketPlan1.setQuotaWarning(4);
+	bucketPlan1.setServiceSettings(settings1);
 
 	/*
 	 * Plan 2: No quota, encrypted, filesystem, access-during-outage.

--- a/src/test/java/com/emc/ecs/common/Fixtures.java
+++ b/src/test/java/com/emc/ecs/common/Fixtures.java
@@ -21,6 +21,9 @@ import com.emc.ecs.cloudfoundry.broker.repository.ServiceInstance;
 import com.emc.ecs.cloudfoundry.broker.repository.ServiceInstanceBinding;
 
 public class Fixtures {
+    private static final String QUOTA = "quota";
+    private static final String WARN = "warn";
+    private static final String LIMIT = "limit";
     private static final String UNLIMITED = "Unlimited";
     private static final String ONE_YEAR = "one-year";
     private static final int ONE_YEAR_IN_SECS = 31536000;
@@ -73,9 +76,9 @@ public class Fixtures {
 	 */
 	Map<String, Object> settings1 = new HashMap<>();
 	Map<String, Object> quota = new HashMap<>();
-	quota.put("limit", 5);
-	quota.put("warn", 4);
-	settings1.put("quota", quota);
+	quota.put(LIMIT, 5);
+	quota.put(WARN, 4);
+	settings1.put(QUOTA, quota);
 	PlanProxy bucketPlan1 = new PlanProxy(BUCKET_PLAN_ID1, _5GB,
 		FREE_TRIAL, null, true);
 	bucketPlan1.setServiceSettings(settings1);
@@ -108,12 +111,12 @@ public class Fixtures {
 	 */
 	Map<String, Object> settings1 = new HashMap<>();
 	Map<String, Object> quota = new HashMap<>();
-	quota.put("limit", 5);
-	quota.put("warn", 4);
+	quota.put(LIMIT, 5);
+	quota.put(WARN, 4);
 	PlanProxy namespacePlan1 = new PlanProxy(NAMESPACE_PLAN_ID1, _5GB,
 		FREE_TRIAL, null, true);
 	settings1.put("default-bucket-quota", 5);
-	settings1.put("quota", quota);
+	settings1.put(QUOTA, quota);
 	namespacePlan1.setServiceSettings(settings1);
 
 	/*

--- a/src/test/java/com/emc/ecs/management/sdk/BucketQuotaActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/BucketQuotaActionTest.java
@@ -11,7 +11,7 @@ import com.emc.ecs.cloudfoundry.broker.EcsManagementResourceNotFoundException;
 import com.emc.ecs.common.EcsActionTest;
 import com.emc.ecs.management.sdk.BucketAction;
 import com.emc.ecs.management.sdk.BucketQuotaAction;
-import com.emc.ecs.management.sdk.model.ObjectBucketInfo;
+import com.emc.ecs.management.sdk.model.BucketQuotaDetails;
 
 public class BucketQuotaActionTest extends EcsActionTest {
     private String bucket = "testbucket3";
@@ -34,13 +34,13 @@ public class BucketQuotaActionTest extends EcsActionTest {
 	    throws EcsManagementClientException,
 	    EcsManagementResourceNotFoundException {
 	BucketQuotaAction.create(connection, bucket, namespace, 10, 8);
-	ObjectBucketInfo bucketInfo = BucketAction.get(connection, bucket,
+	BucketQuotaDetails quotaDetails = BucketQuotaAction.get(connection, bucket,
 		namespace);
-	assertEquals(10, bucketInfo.getBlockSize());
-	assertEquals(8, bucketInfo.getNotificationSize());
+	assertEquals(10, quotaDetails.getBlockSize());
+	assertEquals(8, quotaDetails.getNotificationSize());
 	BucketQuotaAction.delete(connection, bucket, namespace);
-	bucketInfo = BucketAction.get(connection, bucket, namespace);
-	assertEquals(-1, bucketInfo.getBlockSize());
-	assertEquals(-1, bucketInfo.getNotificationSize());
+	quotaDetails = BucketQuotaAction.get(connection, bucket, namespace);
+	assertEquals(-1, quotaDetails.getBlockSize());
+	assertEquals(-1, quotaDetails.getNotificationSize());
     }
 }

--- a/src/test/java/com/emc/ecs/management/sdk/BucketQuotaActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/BucketQuotaActionTest.java
@@ -9,8 +9,6 @@ import org.junit.Test;
 import com.emc.ecs.cloudfoundry.broker.EcsManagementClientException;
 import com.emc.ecs.cloudfoundry.broker.EcsManagementResourceNotFoundException;
 import com.emc.ecs.common.EcsActionTest;
-import com.emc.ecs.management.sdk.BucketAction;
-import com.emc.ecs.management.sdk.BucketQuotaAction;
 import com.emc.ecs.management.sdk.model.BucketQuotaDetails;
 
 public class BucketQuotaActionTest extends EcsActionTest {

--- a/src/test/java/com/emc/ecs/management/sdk/BucketQuotaActionTest.java
+++ b/src/test/java/com/emc/ecs/management/sdk/BucketQuotaActionTest.java
@@ -34,8 +34,8 @@ public class BucketQuotaActionTest extends EcsActionTest {
 	    throws EcsManagementClientException,
 	    EcsManagementResourceNotFoundException {
 	BucketQuotaAction.create(connection, bucket, namespace, 10, 8);
-	BucketQuotaDetails quotaDetails = BucketQuotaAction.get(connection, bucket,
-		namespace);
+	BucketQuotaDetails quotaDetails = BucketQuotaAction.get(connection,
+		bucket, namespace);
 	assertEquals(10, quotaDetails.getBlockSize());
 	assertEquals(8, quotaDetails.getNotificationSize());
 	BucketQuotaAction.delete(connection, bucket, namespace);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -32,8 +32,10 @@ catalog:
         - id: 09cac5b8-1b0a-11e6-b6ba-3e1d05defe78
           name: 5gb
           description: Free Trial
-          quota-limit: 5
-          quota-warning: 4
+          service-settings:
+            quota:
+              limit: 5
+              warning: 4
           metadata:
             costs:
               - amount:
@@ -67,8 +69,10 @@ catalog:
         - id: 8e777d49-0a78-4cf4-810a-b5f5173b019d
           name: 5gb
           description: Free Trial
-          quota-limit: 5
-          quota-warning: 4
+          service-settings:
+            quota:
+              limit: 5
+              warning: 4
           metadata:
             costs:
               - amount:

--- a/src/test/resources/mappings/bucket-delete2-testbucket3.json
+++ b/src/test/resources/mappings/bucket-delete2-testbucket3.json
@@ -1,0 +1,23 @@
+{
+	"scenarioName": "testbucket3",
+    "requiredScenarioState": "Quota updated",
+    "newScenarioState": "Started",
+    "request": {
+        "method": "POST",
+        "url": "/object/bucket/testbucket3/deactivate?namespace=ns1",
+        "headers": {
+        	"Accept": {
+        		"equalTo": "application/xml"
+        	},
+        	"X-SDS-AUTH-TOKEN" : {
+        		"equalTo": "BAAcY1U1UTNSRGRCUnViRXl1UDZDZDdhbWFuaGRZPQMAQQIADTE0NTAwNjU5ODc1MjMDAC51cm46VG9rZW46ODExN2ViY2YtYTliMi00NGExLTliYmUtNTM2ODQwMzk2Nzc1AgAC0A8"
+        	}
+        }
+    },
+    "response": {
+        "status": "200",
+        "headers": {
+			"Content-Type": "application/xml"
+		}
+	}
+}

--- a/src/test/resources/mappings/bucket-quota-info-testbucket3.json
+++ b/src/test/resources/mappings/bucket-quota-info-testbucket3.json
@@ -1,0 +1,23 @@
+{
+	"scenarioName": "testbucket3",
+    "requiredScenarioState": "Quota updated",
+    "request": {
+        "method": "GET",
+        "url": "/object/bucket/testbucket3/quota?namespace=ns1",
+        "headers": {
+        	"Accept": {
+        		"equalTo": "application/xml"
+        	},
+        	"X-SDS-AUTH-TOKEN" : {
+        		"equalTo": "BAAcY1U1UTNSRGRCUnViRXl1UDZDZDdhbWFuaGRZPQMAQQIADTE0NTAwNjU5ODc1MjMDAC51cm46VG9rZW46ODExN2ViY2YtYTliMi00NGExLTliYmUtNTM2ODQwMzk2Nzc1AgAC0A8"
+        	}
+        }
+    },
+    "response": {
+        "status": "200",
+        "headers": {
+			"Content-Type": "application/xml"
+		},
+		"body": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><bucket_quota_details><blockSize>10</blockSize><namespace>ns1</namespace><notificationSize>8</notificationSize></bucket_quota_details>"
+	}
+}

--- a/src/test/resources/mappings/bucket-quota-info2-testbucket3.json
+++ b/src/test/resources/mappings/bucket-quota-info2-testbucket3.json
@@ -1,0 +1,23 @@
+{
+	"scenarioName": "testbucket3",
+    "requiredScenarioState": "Created",
+    "request": {
+        "method": "GET",
+        "url": "/object/bucket/testbucket3/quota?namespace=ns1",
+        "headers": {
+        	"Accept": {
+        		"equalTo": "application/xml"
+        	},
+        	"X-SDS-AUTH-TOKEN" : {
+        		"equalTo": "BAAcY1U1UTNSRGRCUnViRXl1UDZDZDdhbWFuaGRZPQMAQQIADTE0NTAwNjU5ODc1MjMDAC51cm46VG9rZW46ODExN2ViY2YtYTliMi00NGExLTliYmUtNTM2ODQwMzk2Nzc1AgAC0A8"
+        	}
+        }
+    },
+    "response": {
+        "status": "200",
+        "headers": {
+			"Content-Type": "application/xml"
+		},
+		"body": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><bucket_quota_details><blockSize>-1</blockSize><namespace>ns1</namespace><notificationSize>-1</notificationSize></bucket_quota_details>"
+	}
+}


### PR DESCRIPTION
Use new service-settings block to configure quota limit & warning.  This also allows catalog creators to set quota settings in either a service or a plan, and allows service-creators the ability to set quotas when there isn't one specified in the service or plan.