### PR TITLE
quota format is "warn" not "warning"

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,7 +59,7 @@ catalog:
           service-settings:
             quota:
               limit: 5
-              warning: 4
+              warn: 4
           metadata:
             costs:
               - amount:
@@ -97,7 +97,7 @@ catalog:
           service-settings:
             quota:
               limit: 5
-              warning: 4
+              warn: 4
           free: true
           metadata:
             costs:


### PR DESCRIPTION
The default `application.yml` had an incorrect entry in the plans for the quota definition.  The quota format was:

```yaml
  quota:
    limit:  5
    warning: 4
```

It should have been:

```yaml
  quota:
    limit: 5
    warn: 4
```

This closes #65 